### PR TITLE
client: cleanup / streamline config initialization

### DIFF
--- a/client/src/main/kotlin/meteor/plugins/Plugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/Plugin.kt
@@ -11,8 +11,7 @@ import meteor.ui.overlay.Overlay
 import meteor.config.legacy.Config
 
 open class Plugin : EventSubscriber() {
-    open val config: Config? = null
-    var javaConfig: Config? = null
+    var configuration: Config? = null
 
     var client = Main.client
     val overlayManager = Main.overlayManager
@@ -29,14 +28,15 @@ open class Plugin : EventSubscriber() {
 
     fun javaConfiguration(clazz: Class<out Config>): Config {
         val c: Config = getConfig(clazz)!!
-        setDefaultConfiguration(c.javaClass, false)
-        javaConfig = c
+        setDefaultConfiguration(c, false)
+        configuration = c
         return c
     }
 
     inline fun <reified T : Config> configuration(): T {
         val config = getConfig(T::class.java) as T
         setDefaultConfiguration(config, false)
+        configuration = config
         return config
     }
 

--- a/client/src/main/kotlin/meteor/plugins/PluginManager.kt
+++ b/client/src/main/kotlin/meteor/plugins/PluginManager.kt
@@ -207,11 +207,7 @@ object PluginManager {
         if (plugins.filterIsInstance<T>().isNotEmpty())
             throw RuntimeException("Duplicate plugin ${plugin::class.simpleName} not allowed")
 
-        plugin.config?.let {
-            ConfigManager.setDefaultConfiguration(it, false)
-        }
-
-        plugin.javaConfig?.let {
+        plugin.configuration?.let {
             ConfigManager.setDefaultConfiguration(it, false)
         }
 

--- a/client/src/main/kotlin/meteor/plugins/autoalch/AutoAlchPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/autoalch/AutoAlchPlugin.kt
@@ -22,7 +22,7 @@ import kotlin.math.roundToInt
 class AutoAlchPlugin : Plugin() {
     var timeout = 0
     var rand = Random()
-    override val config: AutoAlchConfig = configuration()
+    val config: AutoAlchConfig = configuration()
 
     override fun onStatChanged(it: StatChanged) {
         if (it.skill === Skill.MAGIC) {

--- a/client/src/main/kotlin/meteor/plugins/autobankpin/AutoBankPinPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/autobankpin/AutoBankPinPlugin.kt
@@ -12,7 +12,7 @@ import java.awt.event.KeyEvent.*
 @PluginDescriptor(name = "Auto Bank Pin", description = "Automatically enters your bank pin", enabledByDefault = false)
 class AutoBankPinPlugin : Plugin() {
 
-    override val config = configuration<AutoBankPinConfig>()
+    val config = configuration<AutoBankPinConfig>()
 
     private var first = false
     private var second = false

--- a/client/src/main/kotlin/meteor/plugins/autoclicker/AutoClickerPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/autoclicker/AutoClickerPlugin.kt
@@ -26,7 +26,7 @@ import kotlin.math.*
 
 class AutoClickerPlugin : Plugin() {
 
-    override val config = configuration<AutoClickerConfig>()
+    val config = configuration<AutoClickerConfig>()
 
     private val overlay = overlay(AutoClickerOverlay(this))
 

--- a/client/src/main/kotlin/meteor/plugins/autologhop/AutoLogHop.kt
+++ b/client/src/main/kotlin/meteor/plugins/autologhop/AutoLogHop.kt
@@ -34,7 +34,7 @@ import kotlin.math.abs
 )
 
 class AutoLogHop : Plugin() {
-    override var config = configuration<AutoLogHopConfig>()
+    var config = configuration<AutoLogHopConfig>()
 
     private var login = false
     fun startup() {

--- a/client/src/main/kotlin/meteor/plugins/autologin/AutoLoginPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/autologin/AutoLoginPlugin.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit
     enabledByDefault = false
 )
 class AutoLoginPlugin : Plugin() {
-    override val config = configuration<AutoLoginConfig>()
+    val config = configuration<AutoLoginConfig>()
     private val executor: ScheduledExecutorService = Main.executor
 
     override fun onGameStateChanged(it: GameStateChanged) {

--- a/client/src/main/kotlin/meteor/plugins/autorun/AutoRun.kt
+++ b/client/src/main/kotlin/meteor/plugins/autorun/AutoRun.kt
@@ -9,7 +9,7 @@ import java.util.*
 @PluginDescriptor(name = "AutoRun", description = "Automatically enables run.", enabledByDefault = true)
 
 class AutoRun : Plugin() {
-    override val config = configuration<AutoRunConfig>()
+    val config = configuration<AutoRunConfig>()
     private val clientThread: ClientThread = ClientThread
     private val rand = Random()
     private var nextRunThreshhold = -1

--- a/client/src/main/kotlin/meteor/plugins/autorun/AutoRunPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/autorun/AutoRunPlugin.kt
@@ -10,7 +10,7 @@ import java.util.*
 @PluginDescriptor(name = "AutoRun", description = "Automatically enables run.", enabledByDefault = true)
 
 class AutoRunPlugin : Plugin() {
-    override val config = configuration<AutoRunConfig>()
+    val config = configuration<AutoRunConfig>()
     private val clientThread: ClientThread = ClientThread
     private val rand = Random()
     private var nextRunThreshhold = -1

--- a/client/src/main/kotlin/meteor/plugins/bank/BankPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/bank/BankPlugin.kt
@@ -55,7 +55,7 @@ class BankPlugin : Plugin() {
 
     private val clientThread = ClientThread
     private val itemManager = ItemManager
-    override var config = configuration<BankConfig>()
+    var config = configuration<BankConfig>()
     private val bankSearch = BankSearch
     private val searchHotkeyListener: KeyListener = object : KeyListener {
         override fun keyTyped(e: KeyEvent) {}

--- a/client/src/main/kotlin/meteor/plugins/banksetups/BankSetups.kt
+++ b/client/src/main/kotlin/meteor/plugins/banksetups/BankSetups.kt
@@ -29,7 +29,7 @@ import java.awt.Point
 )
 
 class BankSetups : Plugin() {
-    override var config = configuration<BankSetupConfig>()
+    var config = configuration<BankSetupConfig>()
     var overlay = overlay(BankSetupsOverlay())
     var state: Int = -1
     var itemManager: ItemManager? = null

--- a/client/src/main/kotlin/meteor/plugins/boosts/BoostsPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/boosts/BoostsPlugin.kt
@@ -43,7 +43,7 @@ import java.util.*
     tags = ["combat", "skilling", "overlay"]
 )
 class BoostsPlugin : Plugin() {
-    override var config = configuration<BoostsConfig>()
+    var config = configuration<BoostsConfig>()
     private val boostsOverlay = overlay(BoostsOverlay(config, this))
 
     val skillsToDisplay: MutableSet<Skill> = EnumSet.noneOf(

--- a/client/src/main/kotlin/meteor/plugins/chatfilter/ChatFilterPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/chatfilter/ChatFilterPlugin.kt
@@ -63,7 +63,7 @@ class ChatFilterPlugin : Plugin() {
             return size > MAX_ENTRIES
         }
     }
-    override val config = configuration<ChatFilterConfig>()
+    val config = configuration<ChatFilterConfig>()
     override fun onStart() {
         updateFilteredPatterns()
         client.refreshChat()

--- a/client/src/main/kotlin/meteor/plugins/combatlevel/CombatLevelPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/combatlevel/CombatLevelPlugin.kt
@@ -41,7 +41,7 @@ import java.util.regex.Pattern
     tags = ["wilderness", "attack", "range"]
 )
 class CombatLevelPlugin : Plugin() {
-    override var config = configuration<CombatLevelConfig>()
+    var config = configuration<CombatLevelConfig>()
     private val overlay = overlay(CombatLevelOverlay(config))
     override fun onStart() {
         if (config.wildernessAttackLevelRange()) {

--- a/client/src/main/kotlin/meteor/plugins/continueclicker/ContinueClickerPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/continueclicker/ContinueClickerPlugin.kt
@@ -18,7 +18,7 @@ class ContinueClickerPlugin : Plugin() {
     var clientThread: ClientThread? = null
 
 
-    override val config = configuration<ContinueClickerConfig>()
+    val config = configuration<ContinueClickerConfig>()
 
     override fun onStart() {}
 

--- a/client/src/main/kotlin/meteor/plugins/ctrlplayeroptions/CtrlPlayerOptions.kt
+++ b/client/src/main/kotlin/meteor/plugins/ctrlplayeroptions/CtrlPlayerOptions.kt
@@ -12,7 +12,7 @@ import net.runelite.api.events.MenuOpened
     enabledByDefault = false
 )
 class CtrlPlayerOptions : Plugin() {
-    override val config = configuration<CtrlPlayerOptionsConfig>()
+    val config = configuration<CtrlPlayerOptionsConfig>()
     override fun onStart() {
         KeyManager.registerKeyListener(CtrlKeyListener, CtrlPlayerOptions::class.java)
     }

--- a/client/src/main/kotlin/meteor/plugins/devtools/DevToolsPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/devtools/DevToolsPlugin.kt
@@ -6,7 +6,7 @@ import meteor.plugins.PluginDescriptor
 @PluginDescriptor(name = "Dev Tools", enabledByDefault = false, description = "")
 class DevToolsPlugin : Plugin() {
     // Gets config from ConfigManager, and returns the proper type for accessing
-    override var config = configuration<DevToolsConfig>()
+    var config = configuration<DevToolsConfig>()
 
     // Adds passed overlay to list, which is added/removed on plugin start/stop. Can be called repetitively
     var overlay = overlay(DevToolsOverlay(this))

--- a/client/src/main/kotlin/meteor/plugins/entityhider/EntityHiderPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/entityhider/EntityHiderPlugin.kt
@@ -49,7 +49,7 @@ import java.util.stream.Collectors
     tags = ["npcs"]
 )
 class EntityHiderPlugin : Plugin() {
-    override val config = configuration<EntityHiderConfig>()
+    val config = configuration<EntityHiderConfig>()
     private var hiddenIndices: ArrayList<Int>? = null
     private var animationHiddenIndices: ArrayList<Int>? = null
     private var hideNPCsOnDeathName: MutableSet<String>? = null

--- a/client/src/main/kotlin/meteor/plugins/fishing/FishingPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/fishing/FishingPlugin.kt
@@ -12,7 +12,7 @@ import net.runelite.api.NPC
 
 @PluginDescriptor("Fishing", configGroup = "fishing")
 class FishingPlugin : Plugin() {
-    override var config = configuration<FishingConfig>()
+    var config = configuration<FishingConfig>()
     val spotsOverlay = overlay(FishingSpotOverlay(this, config))
 
     val fishingSpots: ArrayList<NPC> = ArrayList()

--- a/client/src/main/kotlin/meteor/plugins/grounditems/GroundItemsPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/grounditems/GroundItemsPlugin.kt
@@ -70,7 +70,7 @@ import java.util.concurrent.TimeUnit
 class GroundItemsPlugin : Plugin() {
     internal class PriceHighlight(val price: Int, val color: Color)
 
-    override val config = configuration<GroundItemsConfig>()
+    val config = configuration<GroundItemsConfig>()
     var textBoxBounds: Map.Entry<Rectangle, GroundItem>? = null
     var hiddenBoxBounds: Map.Entry<Rectangle, GroundItem>? = null
     var highlightBoxBounds: Map.Entry<Rectangle, GroundItem>? = null

--- a/client/src/main/kotlin/meteor/plugins/interacthighlight/InteractHighlightPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/interacthighlight/InteractHighlightPlugin.kt
@@ -39,7 +39,7 @@ import net.runelite.api.widgets.WidgetInfo
     enabledByDefault = false
 )
 class InteractHighlightPlugin : Plugin() {
-    override val config: InteractHighlightConfig = configuration()
+    val config: InteractHighlightConfig = configuration()
     private val interactHighlightOverlay = overlay(InteractHighlightOverlay(this))
 
     @Getter(AccessLevel.PACKAGE)

--- a/client/src/main/kotlin/meteor/plugins/inventorytags/InventoryTagsPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/inventorytags/InventoryTagsPlugin.kt
@@ -48,7 +48,7 @@ import java.util.*
 )
 class InventoryTagsPlugin : Plugin() {
 
-    override val config: InventoryTagsConfig = configuration()
+    val config: InventoryTagsConfig = configuration()
     private val overlay = overlay(InventoryTagsOverlay(this))
 
     private var editorMode = false

--- a/client/src/main/kotlin/meteor/plugins/itemprices/ItemPricesPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/itemprices/ItemPricesPlugin.kt
@@ -34,7 +34,7 @@ import meteor.plugins.PluginDescriptor
 )
 class ItemPricesPlugin : Plugin() {
 
-    override var config = configuration<ItemPricesConfig>()
+    var config = configuration<ItemPricesConfig>()
     val overlay = overlay(ItemPricesOverlay(this))
 
 }

--- a/client/src/main/kotlin/meteor/plugins/keyremapping/KeyRemappingPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/keyremapping/KeyRemappingPlugin.kt
@@ -22,7 +22,7 @@ import java.awt.Color
     enabledByDefault = false
 )
 class KeyRemappingPlugin : Plugin() {
-    override val config = configuration<KeyRemappingConfig>()
+    val config = configuration<KeyRemappingConfig>()
 
     private val inputListener = KeyRemappingListener
 

--- a/client/src/main/kotlin/meteor/plugins/meteor/Meteor.kt
+++ b/client/src/main/kotlin/meteor/plugins/meteor/Meteor.kt
@@ -6,5 +6,5 @@ import meteor.plugins.PluginDescriptor
 
 @PluginDescriptor(name = "Meteor", enabledByDefault = true)
 class Meteor : Plugin() {
-    override var config = configuration<MeteorConfig>()
+    var config = configuration<MeteorConfig>()
 }

--- a/client/src/main/kotlin/meteor/plugins/minimap/MinimapPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/minimap/MinimapPlugin.kt
@@ -42,7 +42,7 @@ import java.util.*
     tags = ["items", "npcs", "players"]
 )
 class MinimapPlugin : Plugin() {
-    override val config = configuration<MinimapConfig>()
+    val config = configuration<MinimapConfig>()
     private var originalDotSprites: Array<SpritePixels>? = null
 
 

--- a/client/src/main/kotlin/meteor/plugins/mousetooltips/MouseTooltipPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/mousetooltips/MouseTooltipPlugin.kt
@@ -33,6 +33,6 @@ import meteor.plugins.PluginDescriptor
     tags = ["actions", "overlay"]
 )
 class MouseTooltipPlugin : Plugin() {
-    override val config = configuration<MouseTooltipConfig>()
+    val config = configuration<MouseTooltipConfig>()
     private val overlay = overlay(MouseTooltipOverlay(config))
 }

--- a/client/src/main/kotlin/meteor/plugins/objecthider/ObjectHiderPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/objecthider/ObjectHiderPlugin.kt
@@ -14,7 +14,7 @@ import java.util.stream.Collectors
 @PluginDescriptor(name = "Object Hider", description = "Hides various objects", enabledByDefault = false)
 class ObjectHiderPlugin : Plugin() {
 
-    override var config = configuration<ObjectHiderConfig>()
+    var config = configuration<ObjectHiderConfig>()
     private var objectIds = listOf<Int>()
     private var objectNames = listOf<String>()
 

--- a/client/src/main/kotlin/meteor/plugins/objectindicators/ObjectIndicatorsPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/objectindicators/ObjectIndicatorsPlugin.kt
@@ -50,7 +50,7 @@ class ObjectIndicatorsPlugin : Plugin() {
 
     private val overlay = overlay(ObjectIndicatorsOverlay(this))
 
-    override val config = configuration<ObjectIndicatorsConfig>()
+    val config = configuration<ObjectIndicatorsConfig>()
 
     private val gson = Gson()
     override fun onStop() {

--- a/client/src/main/kotlin/meteor/plugins/pvpkeys/PvPKeys.kt
+++ b/client/src/main/kotlin/meteor/plugins/pvpkeys/PvPKeys.kt
@@ -29,7 +29,7 @@ class PvPKeys : Plugin() {
     var r = Random()
     var target: Actor? = null
     private val keyManager = KeyManager
-    override val config = configuration<PvPKeysConfig>()
+    val config = configuration<PvPKeysConfig>()
     var executor: ExecutorService? = null
     val meleeGear: MutableList<String>
         get() = mutableListOf(*config.MeleeIDs()!!.split(",").toTypedArray())

--- a/client/src/main/kotlin/meteor/plugins/rsnhider/RsnHiderPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/rsnhider/RsnHiderPlugin.kt
@@ -44,7 +44,7 @@ class RsnHiderPlugin : Plugin() {
 
 
     private val clientThread = ClientThread
-    override val config = configuration<RsnHiderConfig>()
+    val config = configuration<RsnHiderConfig>()
 
 
     override fun onStart() {

--- a/client/src/main/kotlin/meteor/plugins/statusbars/StatusBarsPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/statusbars/StatusBarsPlugin.kt
@@ -39,7 +39,7 @@ import org.apache.commons.lang3.ArrayUtils
     description = "Draws status bars next to players inventory showing current HP & Prayer and healing amounts"
 )
 class StatusBarsPlugin : Plugin() {
-    override val config = configuration<StatusBarsConfig>()
+    val config = configuration<StatusBarsConfig>()
     private val overlay = overlay(StatusBarsOverlay(this, config))
     private val clientThread = ClientThread
 

--- a/client/src/main/kotlin/meteor/plugins/stretchedmode/StretchedModePlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/stretchedmode/StretchedModePlugin.kt
@@ -40,7 +40,7 @@ import meteor.plugins.PluginDescriptor
     enabledByDefault = true
 )
 class StretchedModePlugin : Plugin() {
-    override val config = configuration<StretchedModeConfig>()
+    val config = configuration<StretchedModeConfig>()
 
     private val mouseManager = MouseManager
     private val mouseListener = TranslateMouseListener

--- a/client/src/main/kotlin/meteor/plugins/tileindicators/TileIndicatorsPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/tileindicators/TileIndicatorsPlugin.kt
@@ -36,7 +36,7 @@ import meteor.plugins.PluginDescriptor
 class TileIndicatorsPlugin : Plugin() {
 
     private val overlay = overlay(TileIndicatorsOverlay(this))
-    override val config: TileIndicatorsConfig = configuration()
+    val config: TileIndicatorsConfig = configuration()
 
 
 }

--- a/client/src/main/kotlin/meteor/plugins/wintertodtfletcher/WintertodtHelper.kt
+++ b/client/src/main/kotlin/meteor/plugins/wintertodtfletcher/WintertodtHelper.kt
@@ -15,7 +15,7 @@ import net.runelite.api.Skill
     enabledByDefault = false
 )
 class WintertodtHelper : Plugin() {
-    override val config = configuration<WintertodtHelperConfig>()
+    val config = configuration<WintertodtHelperConfig>()
     var waitForFullInv = false
     var allowance = 0
     override fun onHitsplatApplied(it: HitsplatApplied) {

--- a/client/src/main/kotlin/meteor/plugins/woodcutting/WoodcuttingPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/woodcutting/WoodcuttingPlugin.kt
@@ -49,7 +49,7 @@ class WoodcuttingPlugin : Plugin() {
 
     var overlay = overlay(WoodcuttingOverlay(this))
     var TREES = overlay(WoodcuttingTreesOverlay(this))
-    override val config = configuration<WoodcuttingConfig>()
+    val config = configuration<WoodcuttingConfig>()
     var session: WoodcuttingSession? = null
         private set
     lateinit var axe: Axe

--- a/client/src/main/kotlin/meteor/plugins/worldmap/WorldMapPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/worldmap/WorldMapPlugin.kt
@@ -54,7 +54,7 @@ import java.util.function.Predicate
     configGroup = "World Map"
 )
 class WorldMapPlugin : Plugin() {
-    override val config = configuration<WorldMapConfig>()
+    val config = configuration<WorldMapConfig>()
 
     var clientThread = ClientThread
     private val worldMapPointManager = WorldMapPointManager

--- a/client/src/main/kotlin/meteor/plugins/worldmapwalker/WorldMapWalkerPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/worldmapwalker/WorldMapWalkerPlugin.kt
@@ -25,7 +25,7 @@ import net.runelite.api.widgets.WidgetInfo
 )
 class WorldMapWalkerPlugin : Plugin() {
     private val worldMapOverlay = overlay(WorldMapOverlay())
-    override var config: WorldMapWalkerConfig = configuration()
+    var config: WorldMapWalkerConfig = configuration()
     var log = Logger("World Map Walker")
     private val overlay = overlay(WorldMapWalkerOverlay(this))
 

--- a/client/src/main/kotlin/meteor/plugins/xptracker/XpTrackerPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/xptracker/XpTrackerPlugin.kt
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit
 )
 class XpTrackerPlugin : Plugin() {
     private val skillIconManager = SkillIconManager
-    override val config = configuration<XpTrackerConfig>()
+    val config = configuration<XpTrackerConfig>()
     private val npcManager = NPCManager
     private val xpClient: XpClient = Main.xpClient
     private val xpState = XpState(config)

--- a/client/src/main/kotlin/meteor/ui/composables/Configuration.kt
+++ b/client/src/main/kotlin/meteor/ui/composables/Configuration.kt
@@ -30,8 +30,7 @@ lateinit var descriptor: ConfigDescriptor
 @Composable
 fun ConfigPanel() {
     when {
-        lastPlugin.config != null -> descriptor = ConfigManager.getConfigDescriptor(lastPlugin.config!!)!!
-        lastPlugin.javaConfig != null -> descriptor = ConfigManager.getConfigDescriptor(lastPlugin.javaConfig!!)!!
+        lastPlugin.configuration != null -> descriptor = ConfigManager.getConfigDescriptor(lastPlugin.configuration!!)!!
     }
     var mod = Modifier.background(darkThemeColors.surface).fillMaxHeight().width(375.dp)
     Column {

--- a/client/src/main/kotlin/meteor/ui/composables/PluginList.kt
+++ b/client/src/main/kotlin/meteor/ui/composables/PluginList.kt
@@ -171,7 +171,7 @@ fun Plugins() {
                             }
 
 
-                            if (plugin.config != null) {
+                            if (plugin.configuration != null) {
                                 Spacer(Modifier.height(20.dp))
                                 IconButton(
                                     onClick = { onPluginConfigurationOpened(plugin) },
@@ -184,20 +184,6 @@ fun Plugins() {
 
                                         )
                                 }
-
-                            } else if (plugin.javaConfig != null) {
-                                Spacer(Modifier.height(20.dp))
-                                IconButton(
-                                    onClick = { onPluginConfigurationOpened(plugin) },
-                                ) {
-                                    Icon(
-                                        Octicons.Gear24,
-                                        contentDescription = "Opens Plugin configuration panel",
-                                        tint = uiColor,
-
-                                        )
-                                }
-
                             } else {
                                 Spacer(
                                     Modifier.width(50.dp)


### PR DESCRIPTION
Plugin.config -> Plugin.configuration, not open

Both configuration() and javaConfiguration() now set to Plugin.configuration

remove overrides from kotlin plugins