### PR TITLE
plugin: Fix xptracker crash when no xp gained

### DIFF
--- a/client/src/main/kotlin/meteor/plugins/xptracker/XpTrackerPluginPanel.kt
+++ b/client/src/main/kotlin/meteor/plugins/xptracker/XpTrackerPluginPanel.kt
@@ -34,254 +34,162 @@ class XpTrackerPluginPanel : PluginPanel() {
 
     @Composable
     override fun Content() {
+        val expHrKeys = expHrMap.filter { it.value > 0 }.keys.toList()
+        if (expHrKeys.isEmpty()) {
+            Column(Modifier.background(surface, RoundedCornerShape(8.dp)).fillMaxHeight().width(300.dp), verticalArrangement = Arrangement.Center, horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = "Exp trackers",
+                    style = TextStyle(fontSize = 18.sp, textAlign = TextAlign.Center, color = Color.White, letterSpacing = 2.sp),
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = "You have not gained experience yet.",
+                    style = TextStyle(fontSize = 12.sp, textAlign = TextAlign.Center, color = Color.Gray, letterSpacing = 2.sp),
+                    textAlign = TextAlign.Center,
+                )
+            }
+        } else {
+            LazyColumn {
+                items(items = expHrKeys) { skill ->
 
-        LazyColumn {
-            items(items = expMap.keys.toList()) { skill ->
-
-                Spacer(Modifier.height(10.dp))
-                Row(
-                    Modifier.background(color = surface, shape = RoundedCornerShape(3.dp)),
-                    horizontalArrangement = Arrangement.SpaceEvenly,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = skill.name.lowercase().replaceFirstChar { it.uppercase() },
-                        style = TextStyle(
-                            fontSize = 20.sp,
-                            textAlign = TextAlign.Center,
-                            color = uiColor.value,
-                            letterSpacing = 2.sp
-                        ),
-                        textAlign = TextAlign.Center,
-                    )
-                }
-                Spacer(Modifier.height(8.dp))
-                Row(
-                    Modifier.background(surface, RoundedCornerShape(8.dp)).height(150.dp).width(300.dp),
-                    horizontalArrangement = Arrangement.SpaceAround,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column(
-                        Modifier.width(32.dp).height(70.dp),
-                        verticalArrangement = Arrangement.SpaceAround,
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-
-                        Image(
-                            painter = painterResource("skill_icons/${skill}.png".lowercase()),
-                            contentDescription = skill.name,
-                            modifier = Modifier.scale(1.5f),
-                        )
+                    Spacer(Modifier.height(10.dp))
+                    Row(Modifier.background(color = surface, shape = RoundedCornerShape(3.dp)), horizontalArrangement = Arrangement.SpaceEvenly, verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            text = client.getRealSkillLevel(skill).toString(),
-                            style = TextStyle(
-                                fontSize = 17.sp,
-                                textAlign = TextAlign.Left,
-                                color = intColor,
-                                letterSpacing = 2.sp
-                            ),
-                            textAlign = TextAlign.Left,
+                            text = skill.name.lowercase().replaceFirstChar { it.uppercase() },
+                            style = TextStyle(fontSize = 20.sp, textAlign = TextAlign.Center, color = uiColor.value, letterSpacing = 2.sp),
+                            textAlign = TextAlign.Center,
                         )
                     }
-                    Column(Modifier.width(130.dp)) {
+                    Spacer(Modifier.height(8.dp))
+                    Row(Modifier.background(surface, RoundedCornerShape(8.dp)).height(150.dp).width(300.dp), horizontalArrangement = Arrangement.SpaceAround, verticalAlignment = Alignment.CenterVertically) {
+                        Column(Modifier.width(32.dp).height(70.dp), verticalArrangement = Arrangement.SpaceAround, horizontalAlignment = Alignment.CenterHorizontally) {
 
-                        Text(
-                            text = "Start XP:",
-                            style = TextStyle(
-                                fontSize = 17.sp,
-                                textAlign = TextAlign.Center,
-                                color = uiColor.value,
-                                letterSpacing = 2.sp
-                            ),
-                            textAlign = TextAlign.Left,
-                        )
-                        Text(
-                            text = "Current XP:",
-                            style = TextStyle(
-                                fontSize = 17.sp,
-                                textAlign = TextAlign.Center,
-                                color = uiColor.value,
-                                letterSpacing = 2.sp
-                            ),
-                            textAlign = TextAlign.Left,
-                        )
-                        Text(
-                            text = "XP Gained:",
-                            style = TextStyle(
-                                fontSize = 17.sp,
-                                textAlign = TextAlign.Center,
-                                color = uiColor.value,
-                                letterSpacing = 2.sp
-                            ),
-                            textAlign = TextAlign.Right,
-                        )
-
-                        Row {
+                            Image(
+                                painter = painterResource("skill_icons/${skill}.png".lowercase()),
+                                contentDescription = skill.name,
+                                modifier = Modifier.scale(1.5f),
+                            )
                             Text(
-                                text = "XP Until ",
-                                style = TextStyle(
-                                    fontSize = 17.sp,
-                                    textAlign = TextAlign.Center,
-                                    color = uiColor.value,
-                                    letterSpacing = 2.sp
-                                ),
+                                text = client.getRealSkillLevel(skill).toString(),
+                                style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Left, color = intColor, letterSpacing = 2.sp),
+                                textAlign = TextAlign.Left,
+                            )
+                        }
+                        Column(Modifier.width(130.dp)) {
+
+                            Text(
+                                text = "Start XP:",
+                                style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, color = uiColor.value, letterSpacing = 2.sp),
                                 textAlign = TextAlign.Left,
                             )
                             Text(
-                                text = ("${(client.getRealSkillLevel(skill) + 1)}:").toString(),
-                                style = TextStyle(
-                                    fontSize = 17.sp,
-                                    textAlign = TextAlign.Center,
-                                    color = intColor,
-                                    letterSpacing = 2.sp
-                                ),
+                                text = "Current XP:",
+                                style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, color = uiColor.value, letterSpacing = 2.sp),
+                                textAlign = TextAlign.Left,
+                            )
+                            Text(
+                                text = "XP Gained:",
+                                style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, color = uiColor.value, letterSpacing = 2.sp),
                                 textAlign = TextAlign.Right,
                             )
-                        }
-                        Text(
-                            text = "XP/hr:",
-                            style = TextStyle(
-                                fontSize = 17.sp,
-                                textAlign = TextAlign.Center,
-                                color = uiColor.value,
-                                letterSpacing = 2.sp
-                            ),
-                            textAlign = TextAlign.Left,
-                        )
-                        Text(
-                            text = "${Main.xpTrackerService.getActionType(skill)?.type}/hr:",
-                            style = TextStyle(
-                                fontSize = 17.sp,
-                                textAlign = TextAlign.Center,
-                                color = uiColor.value,
-                                letterSpacing = 2.sp
-                            ),
-                            textAlign = TextAlign.Left,
-                        )
-                    }
-                    Column{
 
-                        startExp.forEach {
-                            if (it.first == skill)
+                            Row {
                                 Text(
-                                    text = it.second.toString(),
-                                    style = TextStyle(
-                                        fontSize = 17.sp,
-                                        textAlign = TextAlign.Center,
-                                        color = intColor,
-                                        letterSpacing = 2.sp
-                                    ),
-                                    textAlign = TextAlign.Center,
+                                    text = "XP Until ",
+                                    style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, color = uiColor.value, letterSpacing = 2.sp),
+                                    textAlign = TextAlign.Left,
                                 )
-                        }
-
-                        expMap.forEach {
-                           if(it.value == client.getSkillExperience(skill))
                                 Text(
-                                    text = it.value.toString(),
-                                    style = TextStyle(
-                                        fontSize = 17.sp,
-                                        textAlign = TextAlign.Center,
-                                        color = intColor,
-                                        letterSpacing = 2.sp
-                                    ),
+                                    text = ("${(client.getRealSkillLevel(skill) + 1)}:").toString(),
+                                    style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, color = intColor, letterSpacing = 2.sp),
+                                    textAlign = TextAlign.Right,
+                                )
+                            }
+                            Text(
+                                text = "XP/hr:",
+                                style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, color = uiColor.value, letterSpacing = 2.sp),
+                                textAlign = TextAlign.Left,
+                            )
+                            Text(
+                                text = "${Main.xpTrackerService.getActionType(skill)?.type}/hr:",
+                                style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, color = uiColor.value, letterSpacing = 2.sp),
+                                textAlign = TextAlign.Left,
+                            )
+                        }
+                        Column {
+
+                            startExp.forEach {
+                                if (it.first == skill) Text(
+                                    text = it.second.toString(),
+                                    style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, color = intColor, letterSpacing = 2.sp),
                                     textAlign = TextAlign.Center,
                                 )
                             }
-                        startExp.forEach {
-                            if (it.first == skill)
-                                Text(
-                                    text = (client.getSkillExperience(skill) - it.second).toString(),
-                                    style = TextStyle(
-                                        fontSize = 17.sp,
-                                        textAlign = TextAlign.Center,
-                                        color = intColor,
-                                        letterSpacing = 2.sp
-                                    ),
+
+                            expMap.forEach {
+                                if (it.value == client.getSkillExperience(skill)) Text(
+                                    text = it.value.toString(),
+                                    style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, color = intColor, letterSpacing = 2.sp),
                                     textAlign = TextAlign.Center,
                                 )
-                        }
-                        Text(
-                            text = (getXpForLevel((client.getRealSkillLevel(skill) + 1)) - client.getSkillExperience(
-                                skill
-                            )).toString(),
-                            style = TextStyle(
-                                fontSize = 17.sp,
-                                textAlign = TextAlign.Center,
-                                color = intColor,
-                                letterSpacing = 2.sp
-                            ),
-                            textAlign = TextAlign.Center,
-                        )
-                        expHrMap.forEach{
-                        if(it.key == skill)
-                            Text(
-                                text = if(it.value > 0)it.value.toString()else "-/-",
-                                style = TextStyle(
-                                    fontSize = 17.sp,
+                            }
+                            startExp.forEach {
+                                if (it.first == skill) Text(
+                                    text = (client.getSkillExperience(skill) - it.second).toString(),
+                                    style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, color = intColor, letterSpacing = 2.sp),
                                     textAlign = TextAlign.Center,
-                                    letterSpacing = 2.sp,
-                                    color = intColor
-                                ),
+                                )
+                            }
+                            Text(
+                                text = (getXpForLevel((client.getRealSkillLevel(skill) + 1)) - client.getSkillExperience(skill)).toString(),
+                                style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, color = intColor, letterSpacing = 2.sp),
                                 textAlign = TextAlign.Center,
                             )
-                        }
-                        actionsHrMap.forEach {
-                        if (it.key == skill)
-                            Text(
-                                text = it.value.toString(),
-                                style = TextStyle(
-                                    fontSize = 17.sp,
+                            expHrMap.forEach {
+                                if (it.key == skill) Text(
+                                    text = if (it.value > 0) it.value.toString() else "-/-",
+                                    style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, letterSpacing = 2.sp, color = intColor),
                                     textAlign = TextAlign.Center,
-                                    letterSpacing = 2.sp,
-                                    color = intColor
-                                ),
-                                textAlign = TextAlign.Center,
-                            )
+                                )
+                            }
+                            actionsHrMap.forEach {
+                                if (it.key == skill) Text(
+                                    text = it.value.toString(),
+                                    style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, letterSpacing = 2.sp, color = intColor),
+                                    textAlign = TextAlign.Center,
+                                )
+                            }
                         }
                     }
-                }
 
-                Row(horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(2.dp)) {
+                    Row(horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(2.dp)) {
 
-                    val start = getXpForLevel(client.getRealSkillLevel(skill))
-                    val curr = client.getSkillExperience(skill)
-                    val xpGained = (curr - start).toDouble()
-                    val end = getXpForLevel(client.getRealSkillLevel(skill) + 1)
-                    val startFloat = (start / end).toDouble().toFloat()
-                    val endFloat = (end / start).toDouble().toFloat()
-
-                    val xpGoal = (end - start).toDouble()
-                    val skillProgress = (xpGained / xpGoal).toFloat()
-                    val progress = ((xpGained / xpGoal) * 100).roundToInt()
-                    BoxWithConstraints(contentAlignment = Alignment.Center) {
-                        Box {
-                            LinearProgressIndicator(
-                                modifier = Modifier.width(295.dp).height(20.dp).progressSemantics(
-                                    value = skillProgress,
-                                    valueRange = startFloat..endFloat
-                                ).background(shape = RoundedCornerShape(3.dp), color = surface),
-                                color = uiColor.value,
-                                backgroundColor = surface,
-                                progress = if (skillProgress > 1.00f) 1.00f else skillProgress
-                            )
-                        }
-                        Box {
-                            Text(
-                                text = if (progress > 1.00f) "100%" else "$progress%",
-                                style = TextStyle(
-                                    fontSize = 17.sp,
+                        val start = getXpForLevel(client.getRealSkillLevel(skill))
+                        val curr = client.getSkillExperience(skill)
+                        val xpGained = (curr - start).toDouble()
+                        val end = getXpForLevel(client.getRealSkillLevel(skill) + 1)
+                        val startFloat = (start / end).toDouble().toFloat()
+                        val endFloat = if (start != 0) (end / start).toDouble().toFloat() else 0f
+                        val xpGoal = (end - start).toDouble()
+                        val skillProgress = (xpGained / xpGoal).toFloat()
+                        val progress = ((xpGained / xpGoal) * 100).roundToInt()
+                        BoxWithConstraints(contentAlignment = Alignment.Center) {
+                            Box {
+                                LinearProgressIndicator(modifier = Modifier.width(295.dp).height(20.dp).progressSemantics(value = skillProgress, valueRange = startFloat..endFloat).background(shape = RoundedCornerShape(3.dp), color = surface), color = uiColor.value, backgroundColor = surface, progress = if (skillProgress > 1.00f) 1.00f else skillProgress)
+                            }
+                            Box {
+                                Text(
+                                    text = if (client.getRealSkillLevel(skill) > 98) "100%" else "$progress%",
+                                    style = TextStyle(fontSize = 17.sp, textAlign = TextAlign.Center, color = if (progress >= 50) Color.Black else intColor, letterSpacing = 2.sp),
                                     textAlign = TextAlign.Center,
-                                    color = if (progress >= 50) Color.Black else intColor,
-                                    letterSpacing = 2.sp
-                                ),
-                                textAlign = TextAlign.Center,
-                            )
+                                )
+                            }
                         }
                     }
-                }
 
+                }
             }
         }
+
     }
 }


### PR DESCRIPTION
- Fix bug where client would crash when opening the xp tracker panel when no xp has been gained
- Instead of showing all skills only show skills where xp has been gained
- Show placeholder if no xp has been gained in any skills