### PR TITLE
client: remove dpiaware jvm arg

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -122,7 +122,6 @@ compose {
             }
             jvmArgs(
                 "-ea",
-                "-Dsun.java2d.dpiaware=false,",
                 "--add-exports", "java.base/java.lang=ALL-UNNAMED",
                 "--add-opens", "java.base/java.net=ALL-UNNAMED",
                 "--add-exports", "java.desktop/sun.awt=ALL-UNNAMED",


### PR DESCRIPTION
The jvm arg that this replaced is no longer needed due to the bug of dropdown text being horribly offset not existing anymore.
That makes this flag redundant because we can use default Compose behavior.