### PR TITLE
eventInspector: Add get/setGraphicHeight methods to RSActor

### DIFF
--- a/api-rs/src/main/java/net/runelite/rs/api/RSActor.java
+++ b/api-rs/src/main/java/net/runelite/rs/api/RSActor.java
@@ -98,6 +98,14 @@ public interface RSActor extends RSRenderable, Actor
 	@Override
 	void setGraphic(int id);
 
+	@Import("spotAnimHeight")
+	@Override
+	int getGraphicHeight();
+
+	@Import("spotAnimHeight")
+	@Override
+	void setGraphicHeight(int height);
+
 	@Import("spotAnimationFrame")
 	int getSpotAnimFrame();
 


### PR DESCRIPTION
Adding `getSetGraphicHeight` and `setGraphicHeight` to fix EventInspector invoking `getGraphicHeight()`