### PR TITLE
Event Inspector Patches

### DIFF
--- a/client/src/main/java/net/runelite/client/plugins/devtools/EventInspector.java
+++ b/client/src/main/java/net/runelite/client/plugins/devtools/EventInspector.java
@@ -2227,6 +2227,8 @@ public class EventInspector extends EventInspectorSubscriber {
 
     @Override
     public void open() {
+        if (isVisible()) return;
+
         resetOutputFile();
         if (settingsFile.exists()) {
             readSettingsFile();
@@ -2412,6 +2414,8 @@ public class EventInspector extends EventInspectorSubscriber {
 
     @Override
     public void close() {
+        if (!isVisible()) return;
+
         super.close();
         tracker.removeAll();
         writeToFile();

--- a/client/src/main/kotlin/meteor/plugins/defaultworld/DefaultWorldPlugin.kt
+++ b/client/src/main/kotlin/meteor/plugins/defaultworld/DefaultWorldPlugin.kt
@@ -54,6 +54,11 @@ class DefaultWorldPlugin : Plugin() {
                     return@subscribe
                 }
 
+                val world = ConfigManager.getConfiguration("defaultworld", "lastWorld")?.toIntOrNull()
+                if (world == client.world) {
+                    return@subscribe
+                }
+
                 ConfigManager.setConfiguration("defaultworld", "lastWorld", client.world)
             }
         }


### PR DESCRIPTION
Fixes issue where the configuration would write for world when teleporting due to load state->login state.
Removes redundant opening of event inspector.