### PR TITLE
client: add launcher update run configuration

### DIFF
--- a/.idea/runConfigurations/Create_Launcher_Release.xml
+++ b/.idea/runConfigurations/Create_Launcher_Release.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Create Launcher Release" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="client:createLauncherUpdate" />
+        </list>
+      </option>
+      <option name="vmOptions" value="-Xmx2048m" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Refresh_Versions.xml
+++ b/.idea/runConfigurations/Refresh_Versions.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Refresh Versions" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="refreshVersions" />
+        </list>
+      </option>
+      <option name="vmOptions" value="-Xmx2048m" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -194,6 +194,7 @@ tasks {
     }
 
     register<JavaExec>("createLauncherUpdate") {
+        dependsOn("build", "createDistributable")
         classpath(sourceSets["main"].runtimeClasspath)
         mainClass.set("meteor.launcher.CreateLauncherUpdate")
     }

--- a/client/src/main/kotlin/meteor/launcher/CreateLauncherUpdate.kt
+++ b/client/src/main/kotlin/meteor/launcher/CreateLauncherUpdate.kt
@@ -10,26 +10,26 @@ import kotlin.math.ceil
 
 object CreateLauncherUpdate {
     private val release = LauncherUpdate()
-    private val releaseDir = java.io.File(".\\client\\build\\release\\")
-    private val modulesFile = java.io.File("./client/build/compose/binaries/main/app/client/runtime/lib/modules")
+    private val releaseDir = java.io.File(".\\build\\release\\")
+    private val modulesFile = java.io.File("./build/compose/binaries/main/app/client/runtime/lib/modules")
 
     @JvmStatic
     fun main(args: Array<String>) {
         val gson = GsonBuilder().setPrettyPrinting().create()
-        release.version = "164" // Last merged PR is version
+        release.version = "167" // Last merged PR is version
         release.updateInfo = ""
 
         if (releaseDir.exists())
             releaseDir.deleteRecursively()
 
         releaseDir.mkdirs()
-        java.io.File("./client/build/compose/binaries/main/app/client/client.bat")
+        java.io.File("./build/compose/binaries/main/app/client/client.bat")
             .writeText(
                 "%USERPROFILE%\\.meteor\\launcher\\client.exe\n" +
                         "pause")
-        crawlDirectory(java.io.File("./client/build/compose/binaries/main/app/client/"))
+        crawlDirectory(java.io.File("./build/compose/binaries/main/app/client/"))
         handleModuleFiles()
-        java.io.File("./client/build/release/release.json").writeText(gson.toJson(release))
+        java.io.File("./build/release/release.json").writeText(gson.toJson(release))
     }
 
     private fun handleModuleFiles() {
@@ -37,8 +37,8 @@ object CreateLauncherUpdate {
         for ((count, chunk) in modulesChunks.withIndex()) {
             val file = File()
             file.name = "modules\\modules-$count"
-            val targetFile = java.io.File("./client/build/release/modules/modules-$count")
-            java.io.File("./client/build/release/modules/").mkdirs()
+            val targetFile = java.io.File("./build/release/modules/modules-$count")
+            java.io.File("./build/release/modules/").mkdirs()
             targetFile.writeBytes(chunk)
             file.size = chunk.size.toLong()
             file.hash = generateCRC(targetFile)


### PR DESCRIPTION
Previously you would have to run 
```
build createDistributable
```
then you would have to run CreateLauncherUpdate().main() to create the release we use in client/build/release

With the new run configuration added (you will see it after next pull), you can simply run the new configuration "Create Launcher Release" and it will build, package, and bootstrap it for you into the build/release folder.