### PR TITLE
client: make questhelper remember bank items between sessions

### DIFF
--- a/client/src/main/java/com/questhelper/QuestBank.java
+++ b/client/src/main/java/com/questhelper/QuestBank.java
@@ -118,7 +118,6 @@ public class QuestBank
 
 	public void saveBankToConfig()
 	{
-		Main.INSTANCE.getLogger().error("saving bank items");
 		configManager.setConfiguration(CONFIG_GROUP, BANK_KEY, gson.toJson(questBankData.getIdAndQuantity()));
 	}
 

--- a/client/src/main/java/com/questhelper/QuestBank.java
+++ b/client/src/main/java/com/questhelper/QuestBank.java
@@ -35,6 +35,7 @@ import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import meteor.Main;
 import meteor.config.ConfigManager;
+import meteor.plugins.PluginManager;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
 import net.runelite.api.WorldType;
@@ -86,7 +87,7 @@ public class QuestBank
 
 	public void loadState()
 	{
-		if (!lastUsername.equalsIgnoreCase(Objects.requireNonNull(client.getLocalPlayer()).getName())) {
+		if (lastUsername == null || !lastUsername.equalsIgnoreCase(Objects.requireNonNull(client.getLocalPlayer()).getName())) {
 			lastUsername = client.getLocalPlayer().getName();
 			loadBankFromConfig();
 		}
@@ -112,15 +113,12 @@ public class QuestBank
 			saveBankToConfig();
 		}
 		bankItems = questBankData.getAsList();
+		saveBankToConfig();
 	}
 
 	public void saveBankToConfig()
 	{
-		if (rsProfileKey == null)
-		{
-			return;
-		}
-
+		Main.INSTANCE.getLogger().error("saving bank items");
 		configManager.setConfiguration(CONFIG_GROUP, BANK_KEY, gson.toJson(questBankData.getIdAndQuantity()));
 	}
 

--- a/client/src/main/java/com/questhelper/QuestHelperPlugin.java
+++ b/client/src/main/java/com/questhelper/QuestHelperPlugin.java
@@ -403,9 +403,12 @@ public class QuestHelperPlugin extends Plugin
 
 		if (state == GameState.LOGIN_SCREEN)
 		{
-			questBank.saveBankToConfig();
-			//SwingUtilities.invokeLater(() -> panel.refresh(Collections.emptyList(), true, new HashMap<>()));
-			questBank.emptyState();
+			if (questBank.getBankItems().size() > 0) {
+				questBank.saveBankToConfig();
+				//SwingUtilities.invokeLater(() -> panel.refresh(Collections.emptyList(), true, new HashMap<>()));
+				questBank.emptyState();
+			}
+
 			if (selectedQuest != null && selectedQuest.getCurrentStep() != null)
 			{
 				shutDownQuest(true);


### PR DESCRIPTION
We don't use RuneLites profiles or sessions. This caused a bug in qh that would prevent it from remembering bank items between sessions.