### PR TITLE
client: fix multiple key keybinds / fix ground items overlay

### DIFF
--- a/client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -453,6 +453,11 @@ public class GroundItemsPlugin extends Plugin
 
 			final WorldPoint worldPoint = WorldPoint.fromScene(client, sceneX, sceneY, client.getPlane());
 			GroundItem groundItem = collectedGroundItems.get(worldPoint, itemId);
+
+			//This can happen if you drop an item before turning on ground items then moving your mouse over it after its enabled
+			if (groundItem == null) {
+				return;
+			}
 			int quantity = groundItem.getQuantity();
 
 			final int gePrice = groundItem.getGePrice();

--- a/client/src/main/kotlin/meteor/config/legacy/Keybind.kt
+++ b/client/src/main/kotlin/meteor/config/legacy/Keybind.kt
@@ -12,9 +12,7 @@ import java.awt.event.KeyEvent
  * key
  */
 
-open class Keybind @JvmOverloads constructor(keyCode: Int, modifiers: Int, ignoreModifiers: Boolean = false) {
-    var keyCode = 0
-    var modifiers = 0
+open class Keybind @JvmOverloads constructor(var keyCode: Int, var modifiers: Int, ignoreModifiers: Boolean = false) {
 
     /**
      * Constructs a keybind with that matches the passed KeyEvent
@@ -67,6 +65,9 @@ open class Keybind @JvmOverloads constructor(keyCode: Int, modifiers: Int, ignor
         if (mod.isEmpty() && key.isEmpty()) {
             return "Not set"
         }
+        //Nullify a duplicate modifier / key to prevent a combo such as Alt + Alt
+        if (mod == key)
+            mod = ""
         if (mod.isNotEmpty() && key.isNotEmpty()) {
             return "$mod+$key"
         }

--- a/client/src/main/kotlin/meteor/config/legacy/ModifierlessKeybind.kt
+++ b/client/src/main/kotlin/meteor/config/legacy/ModifierlessKeybind.kt
@@ -5,6 +5,11 @@ import java.awt.event.KeyEvent
 
 
 class ModifierlessKeybind(keyCode: Int, modifiers: Int) : Keybind(keyCode, modifiers, true) {
+    init {
+        super.keyCode = keyCode
+        super.modifiers = modifiers
+    }
+
     /**
      * Constructs a keybind with that matches the passed KeyEvent
      */

--- a/client/src/main/kotlin/meteor/launcher/CreateLauncherUpdate.kt
+++ b/client/src/main/kotlin/meteor/launcher/CreateLauncherUpdate.kt
@@ -16,7 +16,7 @@ object CreateLauncherUpdate {
     @JvmStatic
     fun main(args: Array<String>) {
         val gson = GsonBuilder().setPrettyPrinting().create()
-        release.version = "170" // Last merged PR is version
+        release.version = "179" // Last merged PR is version
         release.updateInfo = ""
 
         if (releaseDir.exists())


### PR DESCRIPTION
This allows you to define keybinds such as Ctrl + A, and fixes using single modifier keybinds such as Alt.

This also fixes a bug in the recent ground items upstream that prevented it from showing on Alt pressed