### PR TITLE
client: use zgc

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -144,6 +144,9 @@ compose {
 
                 "-ea",
                 "-noverify",
+                "-XX:+UseDynamicNumberOfGCThreads",
+                "-XX:+UseZGC",
+                "-Xmx2048m",
                 "--add-exports", "java.base/java.lang=ALL-UNNAMED",
                 "--add-opens", "java.base/java.net=ALL-UNNAMED",
                 "--add-exports", "java.desktop/sun.awt=ALL-UNNAMED",


### PR DESCRIPTION
We cycle through a lot of memory using kotlin / compose.
This change makes the client use javas newer garbage collection, which will reduce the amount of thrashing and improve performance in general over long sessions.