### PR TITLE
client: use zgc

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -144,6 +144,9 @@ compose {
 
                 "-ea",
                 "-noverify",
+                "-XX:+UseDynamicNumberOfGCThreads",
+                "-XX:+UseZGC",
+                "-Xmx2048m",
                 "--add-exports", "java.base/java.lang=ALL-UNNAMED",
                 "--add-opens", "java.base/java.net=ALL-UNNAMED",
                 "--add-exports", "java.desktop/sun.awt=ALL-UNNAMED",


### PR DESCRIPTION
We cycle through a lot of memory using kotlin / compose.
This change makes the client use javas newer garbage collection, which will reduce the amount of thrashing and improve performance in general over long sessions.

This breaks the client on versions of Windows < 10 (1803)

If this includes you, upgrade your god damn operating system, or you will be required to build source to remove zgc. Thanks!