### PR TITLE
client: do questhelper requirements check on client thread safely

### DIFF
--- a/client/src/main/java/net/runelite/client/plugins/questhelper/QuestHelperPlugin.java
+++ b/client/src/main/java/net/runelite/client/plugins/questhelper/QuestHelperPlugin.java
@@ -41,18 +41,12 @@ import net.runelite.client.plugins.questhelper.overlays.QuestHelperWorldLineOver
 import net.runelite.client.plugins.questhelper.overlays.QuestHelperWorldOverlay;
 import net.runelite.client.plugins.questhelper.questhelpers.QuestDetails;
 import net.runelite.client.plugins.questhelper.questhelpers.QuestHelper;
+import net.runelite.client.plugins.questhelper.requirements.Requirement;
 import net.runelite.client.plugins.questhelper.requirements.item.ItemRequirement;
 import net.runelite.client.plugins.questhelper.steps.QuestStep;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -305,6 +299,35 @@ public class QuestHelperPlugin extends Plugin
 
 	boolean hasSetup = false;
 
+	public ArrayList<RequirementMet> checkRequirements() {
+
+		List<Requirement> generalRequirements = selectedQuest.getGeneralRequirements();
+		ArrayList<RequirementMet> generalRequirementsMet = new ArrayList<>();
+		generalRequirements.forEach(requirement -> {
+			boolean requirementMet = requirement.check(Main.client);
+			generalRequirementsMet.add(new RequirementMet(requirement, requirementMet));
+		});
+		pluginPanel.getGeneralRequirementsMet().setValue(generalRequirementsMet);
+
+		List<ItemRequirement> itemRequirements = selectedQuest.getItemRequirements();
+		ArrayList<RequirementMet> itemRequirementsMet = new ArrayList<>();
+		itemRequirements.forEach(requirement -> {
+			boolean requirementMet = requirement.check(Main.client);
+			itemRequirementsMet.add(new RequirementMet(requirement, requirementMet));
+		});
+		pluginPanel.getItemRequirementsMet().setValue(itemRequirementsMet);
+
+		List<ItemRequirement> itemRecomends = selectedQuest.getItemRecommended();
+		ArrayList<RequirementMet> itemRecomendsMet = new ArrayList<>();
+		itemRecomends.forEach(requirement -> {
+			boolean requirementMet = requirement.check(Main.client);
+			itemRecomendsMet.add(new RequirementMet(requirement, requirementMet));
+		});
+		pluginPanel.getItemRecommendMet().setValue(itemRecomendsMet);
+
+		return itemRecomendsMet;
+	}
+
 	@Override
 	public void onGameTick(GameTick event)
 	{
@@ -362,6 +385,9 @@ public class QuestHelperPlugin extends Plugin
 					//clientThread.invokeLater(() -> panel.updateItemRequirements(client, questBank.getBankItems()));
 				}*/
 				//panel.updateLocks();
+
+				//Ensure this is done on the client thread, so no more crashing.
+				checkRequirements();
 			}
 		}
 		if (loadQuestList)

--- a/client/src/main/java/net/runelite/client/plugins/questhelper/QuestHelperPluginPanel.kt
+++ b/client/src/main/java/net/runelite/client/plugins/questhelper/QuestHelperPluginPanel.kt
@@ -28,14 +28,9 @@ import meteor.ui.composables.preferences.*
 class QuestHelperPluginPanel(var questHelper: QuestHelper) : PluginPanel() {
     var quest = questHelper.quest
 
-    //Dynamic data
-    val generalRequirements = questHelper.generalRequirements
-    val itemRequirements = questHelper.itemRequirements
-    val itemRecommends = questHelper.itemRecommended
-
     //We use mutableStateOf so compose is aware of changes to it, and will redraw
     //Checking requirements met must be done on ClientThread (so not in @Composable function)
-    //Which is why we use EventBus to update requirements met
+    //So the actual checking is done in the plugin onGameTick
     var generalRequirementsMet = mutableStateOf(ArrayList<RequirementMet>())
     var itemRequirementsMet = mutableStateOf(ArrayList<RequirementMet>())
     var itemRecommendMet = mutableStateOf(ArrayList<RequirementMet>())
@@ -43,37 +38,6 @@ class QuestHelperPluginPanel(var questHelper: QuestHelper) : PluginPanel() {
     //Static data
     val enemiesToDefeat = questHelper.combatRequirements
     val rewards = questHelper.questRewards
-
-    init {
-        generalRequirements?.let { updateRequirements(generalRequirements) }
-        itemRequirements?.let { updateRequirements(itemRequirements) }
-        itemRecommends?.let { updateRequirements(itemRecommends) }
-    }
-
-    override fun onGameTick(it: GameTick) {
-        generalRequirements?.let { updateRequirements(generalRequirements) }
-    }
-
-    override fun onItemContainerChanged(it: ItemContainerChanged) {
-        itemRequirements?.let { updateRequirements(itemRequirements) }
-        itemRecommends?.let { updateRequirements(itemRecommends) }
-    }
-
-    fun updateRequirements(requirements: List<Requirement>) {
-        val requirementsMet = ArrayList<RequirementMet>()
-        requirements.forEach {
-            var requirementMet = false
-            try {
-                requirementMet = it.check(Main.client)
-            } catch (_: Exception) {}
-            requirementsMet.add(RequirementMet(it, requirementMet))
-        }
-        when (requirements) {
-            generalRequirements -> generalRequirementsMet.value = requirementsMet
-            itemRequirements -> itemRequirementsMet.value = requirementsMet
-            itemRecommends -> itemRecommendMet.value = requirementsMet
-        }
-    }
 
     @Composable override fun Header() {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.Center,


### PR DESCRIPTION
This makes sure that requirements are checked properly.
This also fixes input lag that would occur when questhelper was active!