### PR TITLE
client: add support for toggling fullscreen without restart

### DIFF
--- a/client/src/main/java/meteor/Hooks.kt
+++ b/client/src/main/java/meteor/Hooks.kt
@@ -168,6 +168,8 @@ class Hooks : Callbacks {
                     // VolatileImage javadocs says this proactively releases the resources used by the VolatileImage
                     stretchedImage?.flush()
 
+                    if (stretchedDimensions.width <= 0 || stretchedDimensions.height <= 0)
+                        return
                     stretchedImage =
                         gc.createCompatibleVolatileImage(stretchedDimensions.width, stretchedDimensions.height)
                     lastStretchedDimensions = stretchedDimensions

--- a/client/src/main/java/meteor/Main.kt
+++ b/client/src/main/java/meteor/Main.kt
@@ -1,6 +1,7 @@
 package meteor
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -9,6 +10,8 @@ import dev.hoot.api.events.AutomatedMenu
 import dev.hoot.api.game.GameThread
 import eventbus.Events
 import eventbus.events.ClickPacket
+import eventbus.events.ConfigChanged
+import eventbus.events.GameTick
 import eventbus.events.MenuOptionClicked
 import meteor.Configuration.EXTERNALS_DIR
 import meteor.api.loot.Interact
@@ -44,12 +47,15 @@ import net.runelite.api.*
 import net.runelite.api.hooks.Callbacks
 import meteor.chat.ChatCommandManager
 import meteor.chat.ChatMessageManager
+import meteor.plugins.Plugin
+import net.runelite.client.plugins.gpu.GpuPlugin
 import net.runelite.http.api.chat.ChatClient
 import net.runelite.http.api.xp.XpClient
 import okhttp3.OkHttpClient
 import org.apache.commons.lang3.time.StopWatch
 import org.jetbrains.skiko.OS
 import org.rationalityfrontline.kevent.KEVENT
+import rs117.hd.HdPlugin
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
@@ -112,28 +118,83 @@ object Main : ApplicationScope, EventSubscriber() {
         // finishStartup is ran here after windowContent()
     }
 
+    val windowPlacement = mutableStateOf(WindowPlacement.Maximized)
+    val windowSize = mutableStateOf(DpSize.Unspecified)
+
+    val windowState = mutableStateOf<WindowState?>(null)
+    val defaultWindowState = mutableStateOf<WindowState?>(null)
+
+    val windowChangeRequired = mutableStateOf(false)
     @Composable
     fun initWindow() {
-        var windowState: WindowState? = rememberWindowState()
+        //We do this to redraw the window
+        if (windowChangeRequired.value) {
+            createWindow()
+        } else {
+            createWindow()
+        }
+    }
+
+    val shouldRender = mutableStateOf(true)
+    var shouldExit = true;
+
+    @Composable
+    fun createWindow() {
+        window?.let {
+            if (!shouldRender.value)
+                if (it.window.isDisplayable) {
+                    while (it.window.isDisplayable) {
+                        it.window.dispose()
+                        Thread.sleep(100)
+                    }
+                }
+        }
+
+        windowState.value = rememberWindowState()
+        defaultWindowState.value = rememberWindowState()
 
         if (meteorConfig.lockWindowSize()) {
             val sizeString = meteorConfig.lockedWindowSize()
 
-            val windowSize = DpSize(
+            windowSize.value = DpSize(
                 sizeString.split(":")[0].toInt().dp,
                 sizeString.split(":")[1].toInt().dp)
 
-            windowState = rememberWindowState(size = windowSize)
+            windowState.value = WindowState(size = windowSize.value)
         }
 
+        if (meteorConfig.fullscreen()) {
+            windowPlacement.value = WindowPlacement.Maximized
+            windowSize.value = DpSize.Unspecified
+            windowState.value = WindowState(placement = windowPlacement.value, size = windowSize.value)
+        }
+
+        if (shouldRender.value)
+            createNewWindow()
+        else {
+            while (window!!.window.isDisplayable) {
+                Thread.sleep(100)
+            }
+            createNewWindow()
+        }
+        shouldExit = true
+        shouldRender.value = true
+    }
+
+    @Composable
+    fun createNewWindow() {
         Window(
-            onCloseRequest = Main::exitApplication,
+            onCloseRequest = {
+                if (shouldExit)
+                    exitApplication()
+                window!!.window.dispose()
+            },
             title = "Meteor",
             icon = painterResource("Meteor_icon.svg"),
             undecorated = meteorConfig.fullscreen(),
             alwaysOnTop = meteorConfig.alwaysOnTop(),
             resizable = !meteorConfig.lockWindowSize(),
-            state = windowState!!,
+            state = windowState.value!!,
             content = {
                 windowContent()
             }
@@ -162,6 +223,9 @@ object Main : ApplicationScope, EventSubscriber() {
         logger.debug("Meteor started in ${timer.getTime(TimeUnit.MILLISECONDS)}ms")
     }
 
+    var gpuNeedsReenabled = false
+    var gpuHDNeedsReenabled = false
+    var lastGPUPluginName = ""
     fun initApi() {
         TileItem.client = client
         Item.client = client
@@ -192,6 +256,50 @@ object Main : ApplicationScope, EventSubscriber() {
             for (menuEntry in copy.keys) {
                 if (it.data.menuEntry.option == menuEntry.menuOption) {
                     onClicksWidget[menuEntry]?.accept(it.data.menuEntry)
+                }
+            }
+        }
+        KEVENT.subscribe<ConfigChanged>(Events.CONFIG_CHANGED) {
+            if (it.data.group == Configuration.MASTER_GROUP)
+                if (it.data.key == "fullscreen") {
+                    shouldExit = false
+                    val gpuIsRunning = PluginManager.get<GpuPlugin>().running
+                    val gpuHdIsRunning = PluginManager.get<HdPlugin>().running
+                    var enabledGPUPlugin = false
+                    if (gpuIsRunning) {
+                        PluginManager.stop(PluginManager.get<GpuPlugin>())
+                        lastGPUPluginName = "GPU"
+                        enabledGPUPlugin = true
+                        gpuNeedsReenabled = true
+                    }
+                    if (gpuHdIsRunning) {
+                        PluginManager.stop(PluginManager.get<HdPlugin>())
+                        lastGPUPluginName = "GPUHD"
+                        enabledGPUPlugin = true
+                        gpuHDNeedsReenabled = true
+                    }
+                    if (!enabledGPUPlugin) {
+                        when (lastGPUPluginName) {
+                            "GPU" -> gpuNeedsReenabled = true
+                            "GPUHD" -> gpuHDNeedsReenabled = true
+                        }
+                    }
+                    shouldRender.value = false
+                }
+        }
+        KEVENT.subscribe<GameTick>(Events.GAME_TICK) {
+            window?.let {
+                if (it.window.isDisplayable) {
+                    if (gpuNeedsReenabled) {
+                        PluginManager.start(PluginManager.get<GpuPlugin>())
+                        if (PluginManager.runningMap[PluginManager.get<GpuPlugin>()]!!)
+                            gpuNeedsReenabled = false
+                    }
+                    if (gpuHDNeedsReenabled) {
+                        PluginManager.start(PluginManager.get<HdPlugin>())
+                        if (PluginManager.runningMap[PluginManager.get<HdPlugin>()]!!)
+                            gpuHDNeedsReenabled = false
+                    }
                 }
             }
         }

--- a/client/src/main/java/meteor/plugins/fullscreen/FullscreenPlugin.kt
+++ b/client/src/main/java/meteor/plugins/fullscreen/FullscreenPlugin.kt
@@ -2,39 +2,89 @@ package meteor.plugins.fullscreen
 
 import androidx.compose.ui.graphics.Color
 import compose.icons.Octicons
+import compose.icons.octicons.ScreenFull24
+import compose.icons.octicons.ScreenNormal24
 import compose.icons.octicons.XCircle24
+import meteor.Configuration
 import meteor.Main
+import meteor.config.ConfigManager
 import meteor.plugins.Plugin
 import meteor.plugins.PluginDescriptor
 import meteor.ui.composables.toolbar.ToolbarButton
 import meteor.ui.composables.toolbar.addButton
 import meteor.ui.composables.toolbar.removeButton
-import kotlin.system.exitProcess
 
 @PluginDescriptor(name = "Notes", enabledByDefault = true, disabledOnStartup = false)
 class FullscreenPlugin : Plugin() {
-    private var notesButton = ToolbarButton(
-            "Notes",
-            Octicons.XCircle24,
-            iconColor = Color.Red,
-            description = "Notes",
-            onClick = {
-                onClick()
-            },
-            bottom = true
+    private var exitApplicationButton = ToolbarButton(
+        "exitMeteor",
+        Octicons.XCircle24,
+        iconColor = Color.Red,
+        description = "Exit Meteor",
+        onClick = {
+            closeMeteor()
+        },
+        bottom = true
     )
 
-    fun onClick() {
+    var enableFullscreenButton = ToolbarButton(
+        "enableFullscreen",
+        Octicons.ScreenFull24,
+        iconColor = Color.Cyan,
+        description = "Toggle Fullscreen",
+        onClick = {
+            toggleFullscreen()
+        },
+        bottom = true
+    )
+
+    var disableFullscreenButton = ToolbarButton(
+        "disableFullscreen",
+        Octicons.ScreenNormal24,
+        iconColor = Color.Cyan,
+        description = "Toggle Fullscreen",
+        onClick = {
+            toggleFullscreen()
+        },
+        bottom = true
+    )
+
+    fun closeMeteor() {
         Main.exitApplication()
+    }
+
+    fun toggleFullscreen() {
+        val isFullscreen = ConfigManager.getConfiguration(Configuration.MASTER_GROUP, "fullscreen")!!.toBoolean()
+        if (isFullscreen) {
+            ConfigManager.setConfiguration(Configuration.MASTER_GROUP, "fullscreen", false)
+            removeButton(disableFullscreenButton)
+            addButton(enableFullscreenButton)
+            removeButton(exitApplicationButton)
+        }
+        else {
+            ConfigManager.setConfiguration(Configuration.MASTER_GROUP, "fullscreen", true)
+            removeButton(enableFullscreenButton)
+            addButton(disableFullscreenButton)
+            addButton(exitApplicationButton)
+        }
     }
 
     override fun onStart() {
         if (Main.meteorConfig.fullscreen())
-            addButton(notesButton)
+            addButton(disableFullscreenButton)
+        else
+            addButton(enableFullscreenButton)
+
+        disableFullscreenButton.position = 998
+        enableFullscreenButton.position = 998
+        if (Main.meteorConfig.fullscreen())
+            addButton(exitApplicationButton)
     }
 
     override fun onStop() {
         if (Main.meteorConfig.fullscreen())
-            removeButton(notesButton)
+            removeButton(disableFullscreenButton)
+        else
+            removeButton(enableFullscreenButton)
     }
 }

--- a/client/src/main/java/meteor/ui/composables/Configuration.kt
+++ b/client/src/main/java/meteor/ui/composables/Configuration.kt
@@ -106,7 +106,7 @@ fun configPanelHeader() {
             Row(
                 verticalAlignment = Alignment.Top,
                 horizontalArrangement = Arrangement.End,
-                modifier = Modifier.width(50.dp)
+                modifier = Modifier.fillMaxWidth()
             ) {
                 TooltipArea(
                     modifier = Modifier.background(

--- a/client/src/main/java/meteor/ui/composables/toolbar/Toolbar.kt
+++ b/client/src/main/java/meteor/ui/composables/toolbar/Toolbar.kt
@@ -2,6 +2,8 @@ package meteor.ui.composables.toolbar
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
@@ -26,14 +28,11 @@ val width = mutableStateOf(Main.meteorConfig.toolbarWidth())
 
 @Composable
 fun ToolbarPanel() {
-    return Column(modifier = Modifier.width(width.value.dp).background(background )) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.fillMaxWidth().fillMaxHeight(.9f).background(surface)
-        ) {
-            MaterialTheme(colors = if (darkLightMode.value)darkThemeColors else lightThemeColors) {
-                topToolbar.sortedBy { it.position }.forEach { it.CreateComponent() }
-            }
+    return Column(modifier = Modifier.width(width.value.dp).background(surface)) {
+        LazyColumn(modifier = Modifier.fillMaxHeight(.8f)) {
+            items(items = topToolbar.sortedBy { it.position }, itemContent = { toolbarButton ->
+                toolbarButton.CreateComponent()
+            })
         }
 
         Column(
@@ -41,7 +40,7 @@ fun ToolbarPanel() {
             modifier = Modifier.fillMaxWidth().fillMaxHeight().background(surface)
         ) {
             MaterialTheme(colors = if (darkLightMode.value)darkThemeColors else lightThemeColors) {
-                for (button in bottomToolbar)
+                for (button in bottomToolbar.sortedBy { it.position })
                     button.CreateComponent()
             }
         }

--- a/client/src/main/java/meteor/ui/composables/toolbar/ToolbarButton.kt
+++ b/client/src/main/java/meteor/ui/composables/toolbar/ToolbarButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,8 +26,8 @@ import meteor.ui.composables.preferences.surface
 import meteor.ui.composables.preferences.uiColor
 
 class ToolbarButton(
-    var name: String, var icon: ImageVector?, var imageResource: String? = null, var iconColor: Color? = null ,
-    var backgroundColor: Color? = null,
+    var name: String, var icon: ImageVector?, var imageResource: String? = null, var iconColor: Color = uiColor.value,
+    var backgroundColor: MutableState<Color> = mutableStateOf(background),
     var description: String? = "", var alignment: Alignment = Alignment.TopCenter,
     var bottom: Boolean = false, var onClick: () -> Unit,
     var position: Int = 999
@@ -42,7 +43,6 @@ class ToolbarButton(
                 name,
                 icon = null,
                 imageResource = imageResource,
-                backgroundColor = mutableStateOf(background).value ,
                 description = description,
                 alignment = alignment,
                 bottom = bottom,
@@ -87,7 +87,7 @@ class ToolbarButton(
                         Icon(
                             icon!!,
                             contentDescription = description,
-                            tint = uiColor.value,
+                            tint = iconColor,
                         )
                     else if (imageResource != null)
                         Image(
@@ -98,7 +98,7 @@ class ToolbarButton(
             }
             Spacer(
                 Modifier.height(10.dp)
-                    .background(background)
+                    .background(backgroundColor.value)
             )
         }
     }

--- a/client/src/main/java/meteor/ui/composables/ui/Window.kt
+++ b/client/src/main/java/meteor/ui/composables/ui/Window.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.FrameWindowScope
 import meteor.Main
+import meteor.Main.shouldRender
 import meteor.ui.composables.configPanel
 import meteor.ui.composables.nodes.sectionItem
 import meteor.ui.composables.preferences.*
@@ -15,48 +16,47 @@ import java.awt.Dimension
 
 @Composable
 fun FrameWindowScope.windowContent() {
+    windowFrame {
+        Main.window = this@windowContent
 
-            windowFrame {
-                Main.window = this@windowContent
+        val width = when {
 
-                val width = when {
+            pluginsOpen.value || configOpen.value || infoPanelOpen.value || hiscoreOpen.value || xpTrackerOpen.value || lootTrackerOpen.value || externalsOpen.value || notesOpen.value -> totalClientWidth
+            else -> totalMinimalWidth
+        }
+        val height = when{
+            consoleOpen.value -> consoleHeight else -> minimumHeight
 
-                    pluginsOpen.value || configOpen.value || infoPanelOpen.value || hiscoreOpen.value || xpTrackerOpen.value || lootTrackerOpen.value || externalsOpen.value || notesOpen.value -> totalClientWidth
-                    else -> totalMinimalWidth
-                }
-                val height = when{
-                    consoleOpen.value -> consoleHeight else -> minimumHeight
-
-                }
-                window.minimumSize = Dimension(width,height)
+        }
+        window.minimumSize = Dimension(width,height)
+        when {
+            toolBarOpen.value -> toolBar {
+                pluginListButton
+            }
+        }
+        Column(
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxHeight().width(15.dp).background(background )
+        ) {
+            Spacer(modifier = Modifier.width(15.dp))
+            sectionItem(modifier = Modifier.background(background ).size(25.dp)) {
                 when {
-                    toolBarOpen.value -> toolBar {
-                        pluginListButton
-                    }
-                }
-                Column(
-                    verticalArrangement = Arrangement.Center,
-                    modifier = Modifier.fillMaxHeight().width(15.dp).background(background )
-                ) {
-                    Spacer(modifier = Modifier.width(15.dp))
-                    sectionItem(modifier = Modifier.background(background ).size(25.dp)) {
-                        when {
-                            !toolBarOpen.value -> toolBarOpen.value = true
-                            toolBarOpen.value -> toolBarOpen.value = false
-                        }
-                    }
-                }
-                content {
-                    when {
-                        pluginPanelIsOpen.value -> pluginPanel.value?.CreateComponent()
-                        configOpen.value -> configPanel()
-                        pluginsOpen.value -> pluginsPanel()
-                    }
-                    gameFrame {
-                        OSRSPanel()
-                    }
+                    !toolBarOpen.value -> toolBarOpen.value = true
+                    toolBarOpen.value -> toolBarOpen.value = false
                 }
             }
+        }
+        content {
+            when {
+                pluginPanelIsOpen.value -> pluginPanel.value?.CreateComponent()
+                configOpen.value -> configPanel()
+                pluginsOpen.value -> pluginsPanel()
+            }
+            gameFrame {
+                OSRSPanel()
+            }
+        }
+    }
 }
 
 

--- a/client/src/main/java/rs117/hd/HdPlugin.java
+++ b/client/src/main/java/rs117/hd/HdPlugin.java
@@ -39,6 +39,7 @@ import meteor.config.ConfigManager;
 import meteor.events.PluginChanged;
 import meteor.plugins.Plugin;
 import meteor.plugins.PluginDescriptor;
+import meteor.plugins.PluginManager;
 import meteor.rs.ClientThread;
 import meteor.ui.DrawManager;
 import meteor.util.OSType;
@@ -511,7 +512,9 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			catch (Throwable err)
 			{
 				log.error("Error while starting 117HD", err);
+				err.printStackTrace();
 				stopPlugin();
+				Main.INSTANCE.setGpuHDNeedsReenabled(true);
 			}
 			return;
 		});
@@ -1962,7 +1965,13 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 		// Texture on UI
 		drawUi(overlayColor, canvasHeight, canvasWidth);
 
-		awtContext.swapBuffers();
+		try {
+			awtContext.swapBuffers();
+		} catch (Exception e) {
+			PluginManager.INSTANCE.stop(this);
+			Main.INSTANCE.setGpuHDNeedsReenabled(true);
+			return;
+		}
 
 		drawManager.processDrawComplete(this::screenshot);
 

--- a/mixins/src/main/java/mixins/StretchedModeMaxSizeMixin.java
+++ b/mixins/src/main/java/mixins/StretchedModeMaxSizeMixin.java
@@ -26,9 +26,16 @@ public abstract class StretchedModeMaxSizeMixin implements RSGameEngine
 			if (client.isResized())
 			{
 				Dimension realDimensions = client.getRealDimensions();
+				int width = realDimensions.width;
+				if (width <= 0)
+					width = 1280;
 
-				setMaxCanvasWidth(realDimensions.width);
-				setMaxCanvasHeight(realDimensions.height);
+				int height = realDimensions.height;
+				if (height <= 0)
+					height = 720;
+
+				setMaxCanvasWidth(width);
+				setMaxCanvasHeight(height);
 			}
 		}
 


### PR DESCRIPTION
- removes the need to restart client when changing fullscreen mode
- adds a fullscreen toggle button to bottom of toolbar
- adds an exit application button to bottom of toolbar when fullscreen
- fixes toolbar button icon color being ignored
- makes toolbar scrollable if top toolbar has many entries
- attempts to re-enable whichever gpu plugin you were last using
(they must be disabled prior to disposing frame)

I've attempted to find every possible crash related to rapid toggling, but you may still find one if you try hard enough. let me know if it happens!

If your gpu plugin doesn't turn back on, either re-toggle fullscreen or toggle the plugin manually, although I've made it pretty robust, it is very rare that it doesn't automatically.