### PR TITLE
client: add instructions composable interface to plugins

### DIFF
--- a/client/src/main/java/meteor/plugins/Plugin.kt
+++ b/client/src/main/java/meteor/plugins/Plugin.kt
@@ -1,5 +1,8 @@
 package meteor.plugins
 
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.runtime.Composable
 import meteor.Main
 import meteor.config.ConfigManager
 import meteor.config.ConfigManager.getConfig
@@ -109,4 +112,7 @@ open class Plugin() : EventSubscriber() {
     }
 
     open fun resetConfiguration() {}
+
+    @Composable
+    open fun instructions() : @Composable (() -> Unit?)? = null
 }

--- a/client/src/main/java/meteor/ui/composables/Configuration.kt
+++ b/client/src/main/java/meteor/ui/composables/Configuration.kt
@@ -30,6 +30,7 @@ import compose.icons.Octicons
 import compose.icons.octicons.ChevronLeft24
 import meteor.config.ConfigManager
 import meteor.plugins.PluginDescriptor
+import meteor.ui.composables.items.instructions
 import meteor.ui.composables.items.configItems
 import meteor.ui.composables.items.sectionItems
 import meteor.ui.composables.items.titleItems
@@ -52,6 +53,7 @@ fun configPanel() {
                     modifier = Modifier.fillMaxHeight()
                 ) {
                     configPanelHeader()
+                    instructions(lastPlugin)
                     configs()
                 }
 

--- a/client/src/main/java/meteor/ui/composables/items/Instructions.kt
+++ b/client/src/main/java/meteor/ui/composables/items/Instructions.kt
@@ -1,0 +1,9 @@
+package meteor.ui.composables.items
+
+import androidx.compose.runtime.Composable
+import meteor.plugins.Plugin
+
+@Composable
+fun instructions(lastPlugin: Plugin) {
+    lastPlugin.instructions()?.invoke()
+}


### PR DESCRIPTION
This allows you to have a Compose instructions panel that will appear above configuratioin items in plugin configs

here is a simple example of how you can include them into a kotlin plugin:

```kotlin
    @Composable
    override fun instructions() : @Composable () -> Unit? {
        return {
            Column (Modifier.height(50.dp)) {
                Text(text = "Instructions go here", color = uiColor.value)
                Text(text = "This is a second row", color = uiColor.value)
            }
        }
    }
```