### PR TITLE
client: improve config panel capabilities

### DIFF
--- a/client/src/main/java/meteor/config/ConfigManager.kt
+++ b/client/src/main/java/meteor/config/ConfigManager.kt
@@ -290,6 +290,30 @@ object ConfigManager {
         return methods
     }
 
+    fun getDefaultConfigValue(config: Any, methodName: String) : String?{
+        var value: String? = null
+        val clazz = config.javaClass.interfaces[0]
+        for (method in getAllDeclaredInterfaceMethods(clazz)) {
+            if (method.name == methodName) {
+                val item: ConfigItem? = method.getAnnotation(ConfigItem::class.java)
+
+                // only get default configuration for methods which read configuration (0 args)
+                if (item == null || method.parameterCount != 0) {
+                    continue
+                }
+
+                val defaultValue: Any = try {
+                    ConfigInvocationHandler.callDefaultMethod(config, method, null)
+                } catch (ex: Throwable) {
+                    ex.printStackTrace()
+                    continue
+                }
+                value = objectToString(defaultValue)
+            }
+        }
+        return value
+    }
+
     fun setDefaultConfiguration(config: Any, override: Boolean) {
         val clazz = config.javaClass.interfaces[0]
         val group: ConfigGroup = clazz.getAnnotation(ConfigGroup::class.java)

--- a/client/src/main/java/meteor/config/legacy/ConfigItem.kt
+++ b/client/src/main/java/meteor/config/legacy/ConfigItem.kt
@@ -25,4 +25,5 @@ package meteor.config.legacy
     val textArea: Boolean = false,
     val textField: Boolean = false,
     val secret: Boolean = false,
+    val composePanel: Boolean = false,
     )

--- a/client/src/main/java/meteor/launcher/CreateLauncherUpdate.kt
+++ b/client/src/main/java/meteor/launcher/CreateLauncherUpdate.kt
@@ -9,7 +9,7 @@ import java.util.zip.CRC32
 import kotlin.math.ceil
 
 object CreateLauncherUpdate {
-    private val releaseVersion = "209"
+    private val releaseVersion = "222"
     private val runtimeVersion = "17.0.5"
 
     private val release = LauncherUpdate()

--- a/client/src/main/java/meteor/plugins/Plugin.kt
+++ b/client/src/main/java/meteor/plugins/Plugin.kt
@@ -8,6 +8,7 @@ import meteor.config.ConfigManager
 import meteor.config.ConfigManager.getConfig
 import meteor.config.ConfigManager.setDefaultConfiguration
 import meteor.config.legacy.Config
+import meteor.ui.composables.composePanelMap
 import meteor.ui.composables.preferences.lastButtonClicked
 import meteor.ui.composables.preferences.pluginPanelIsOpen
 
@@ -113,6 +114,7 @@ open class Plugin() : EventSubscriber() {
 
     open fun resetConfiguration() {}
 
-    @Composable
-    open fun instructions() : @Composable (() -> Unit?)? = null
+    fun setConfigComposable(group: String, key: String, composable: @Composable () -> Unit?) {
+        composePanelMap["$group:$key"] = composable
+    }
 }

--- a/client/src/main/java/meteor/plugins/muspahassist/MuspahAssist.kt
+++ b/client/src/main/java/meteor/plugins/muspahassist/MuspahAssist.kt
@@ -2,9 +2,7 @@
 
 package meteor.plugins.muspahassist
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
@@ -22,21 +20,23 @@ import meteor.config.ConfigManager
 import meteor.plugins.Plugin
 import meteor.plugins.PluginDescriptor
 import meteor.rs.ClientThread
-import meteor.ui.composables.items.updateConfigUI
 import meteor.ui.composables.preferences.secondColor
 import meteor.ui.composables.preferences.surface
 import meteor.ui.composables.preferences.uiColor
+import meteor.ui.composables.updateStringValue
 import net.runelite.api.*
-import net.runelite.api.widgets.WidgetInfo
-import java.awt.Toolkit
-import java.awt.datatransfer.StringSelection
 import java.util.*
 
 
 @PluginDescriptor(name = "Muspah Assist", description = "Auto prays for you at muspah", enabledByDefault = false)
 class MuspahAssist : Plugin() {
-    @Composable
-    override fun instructions() : @Composable () -> Unit? {
+    init {
+        setConfigComposable("muspahassist", "rangeGearButton", rangeGearButton())
+        setConfigComposable("muspahassist", "mageGearButton", mageGearButton())
+        setConfigComposable("muspahassist", "shieldGearButton", shieldGearButton())
+    }
+
+    fun rangeGearButton() : @Composable () -> Unit? {
         return {
             Spacer(Modifier.height(10.dp))
             Text(
@@ -44,7 +44,7 @@ class MuspahAssist : Plugin() {
                 text = "EQUIP YOUR GEAR AND CLICK THE BUTTON",
                 color = secondColor.value,
                 textAlign = TextAlign.Center)
-            Column {
+            Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
                 Spacer(Modifier.height(10.dp))
                 Button(
                     modifier = Modifier.size(200.dp, 40.dp),
@@ -61,7 +61,7 @@ class MuspahAssist : Plugin() {
                                 sb.append(",")
                             }
                             ConfigManager.setConfiguration("muspahassist", "RangeIDs", sb.toString())
-                            updateConfigUI("muspahassist", "RangeIDs", sb.toString())
+                            updateStringValue("muspahassist", "RangeIDs", sb.toString())
                         }
                     },
                     colors = ButtonDefaults.textButtonColors(
@@ -70,6 +70,19 @@ class MuspahAssist : Plugin() {
                 ) {
                     Text("Copy Range Gear", color = uiColor.value)
                 }
+            }
+        }
+    }
+
+    fun mageGearButton() : @Composable () -> Unit? {
+        return {
+            Spacer(Modifier.height(10.dp))
+            Text(
+                style = (TextStyle(fontSize = 12.sp)),
+                text = "EQUIP YOUR GEAR AND CLICK THE BUTTON",
+                color = secondColor.value,
+                textAlign = TextAlign.Center)
+            Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
                 Spacer(Modifier.height(10.dp))
                 Button(
                     modifier = Modifier.size(200.dp, 40.dp),
@@ -86,7 +99,7 @@ class MuspahAssist : Plugin() {
                                 sb.append(",")
                             }
                             ConfigManager.setConfiguration("muspahassist", "MageIDs", sb.toString())
-                            updateConfigUI("muspahassist", "MageIDs", sb.toString())
+                            updateStringValue("muspahassist", "MageIDs", sb.toString())
                         }
                     },
                     colors = ButtonDefaults.textButtonColors(
@@ -95,6 +108,19 @@ class MuspahAssist : Plugin() {
                 ) {
                     Text("Copy Mage Gear", color = uiColor.value)
                 }
+            }
+        }
+    }
+
+    fun shieldGearButton() : @Composable () -> Unit? {
+        return {
+            Spacer(Modifier.height(10.dp))
+            Text(
+                style = (TextStyle(fontSize = 12.sp)),
+                text = "EQUIP YOUR GEAR AND CLICK THE BUTTON",
+                color = secondColor.value,
+                textAlign = TextAlign.Center)
+            Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
                 Spacer(Modifier.height(10.dp))
                 Button(
                     modifier = Modifier.size(200.dp, 40.dp),
@@ -111,7 +137,7 @@ class MuspahAssist : Plugin() {
                                 sb.append(",")
                             }
                             ConfigManager.setConfiguration("muspahassist", "shieldIDs", sb.toString())
-                            updateConfigUI("muspahassist", "shieldIDs", sb.toString())
+                            updateStringValue("muspahassist", "shieldIDs", sb.toString())
                         }
                     },
                     colors = ButtonDefaults.textButtonColors(
@@ -123,6 +149,7 @@ class MuspahAssist : Plugin() {
             }
         }
     }
+
     val mageGear: MutableList<String>
         get() = mutableListOf(*config.MageIDs()!!.split(",").toTypedArray())
     val rangeGear: MutableList<String>

--- a/client/src/main/java/meteor/plugins/muspahassist/MuspahAssistConfig.kt
+++ b/client/src/main/java/meteor/plugins/muspahassist/MuspahAssistConfig.kt
@@ -64,35 +64,68 @@ interface MuspahAssistConfig : Config {
         return false
     }
     @ConfigItem(
+        keyName = "rangeGearButton",
+        name = "",
+        description = "",
+        position = 6,
+        composePanel = true
+    )
+    fun rangeGearButton(): Boolean {
+        return false
+    }
+    @ConfigItem(
         keyName = "RangeIDs",
         name = "Range Gear",
         description = "",
         textField = true,
-        position = 6
+        position = 7
     )
     fun RangeIDs(): String? {
         return ""
+    }
+
+    @ConfigItem(
+        keyName = "mageGearButton",
+        name = "",
+        description = "",
+        position = 8,
+        composePanel = true
+    )
+    fun mageGearButton(): Boolean {
+        return false
     }
     @ConfigItem(
         keyName = "MageIDs",
         name = "Mage Gear",
         description = "",
         textField = true,
-        position = 7
+        position = 9
     )
     fun MageIDs(): String? {
         return ""
+    }
+    @ConfigItem(
+        keyName = "shieldGearButton",
+        name = "",
+        description = "",
+        position = 10,
+        composePanel = true
+    )
+    fun shieldGearButton(): Boolean {
+        return false
     }
     @ConfigItem(
         keyName = "shieldIDs",
         name = "Shield Phase Gear",
         description = "",
         textField = true,
-        position = 8
+        position = 11
     )
     fun ShieldIDs(): String? {
         return ""
     }
+
+
 
     enum class RangeOffensivePrayers(val prayer: Prayer) {
         EAGLE_EYE(Prayer.EAGLE_EYE), RIGOUR(Prayer.RIGOUR);

--- a/client/src/main/java/meteor/ui/composables/items/ConfigItems.kt
+++ b/client/src/main/java/meteor/ui/composables/items/ConfigItems.kt
@@ -1,7 +1,9 @@
 package meteor.ui.composables.items
 
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import meteor.config.ConfigManager
@@ -10,67 +12,10 @@ import meteor.config.legacy.ModifierlessKeybind
 import meteor.ui.composables.nodes.*
 import java.awt.Color
 
-val configStringsMap = HashMap<String, MutableState<String?>>()
+fun LazyListScope.composePanels(descriptor: ConfigDescriptor) {
 
-fun updateConfigUI(group: String, key: String, value: String) {
-    configStringsMap["$group:$key"]?.value = value
 }
 
 fun LazyListScope.configItems(descriptor: ConfigDescriptor) {
-    items(items = descriptor.items.toTypedArray())
-    { config ->
-        if (config.item.section.isEmpty()) {
-            var hidden = true
-            if (!config.item.hidden) {
-                hidden = false
-            }
-            if (config.item.hidden && config.item.unhide.isNotEmpty()) {
-                val value = ConfigManager.getConfiguration(
-                    meteor.ui.composables.preferences.descriptor.group.value,
-                    config.item.unhide
-                )
-                value?.let {
-                    if (it.isNotEmpty())
-                        hidden = !it.toBoolean()
-                }
-            }
-            if (!hidden)
-            when (config.type) {
-                Int::class.javaPrimitiveType, Int::class.java -> {
-                    when {
-                        config.range != null -> sliderIntNode(descriptor, config)
-                        config.item.textArea -> intAreaTextNode(
-                            descriptor,
-                            config
-                        )
-                        else -> intTextNode(descriptor, config)
-                    }
-                }
-                Boolean::class.java -> {
-                    booleanNode(descriptor, config)
-                }
 
-                Color::class.java -> colorPickerNode(descriptor, config)
-                ModifierlessKeybind::class.java -> hotKeyNode(descriptor, config)
-                String::class.java -> {
-                    when {
-                        config.item.textArea -> stringAreaTextNode(descriptor, config)
-                        else -> {
-                            val key = "${descriptor.group.value}:${config.key()}"
-                            configStringsMap[key]?.let {
-                                it.value = ConfigManager.getConfiguration(descriptor.group.value, config.key())
-                            }
-                            if (configStringsMap[key] == null)
-                                configStringsMap[key] = mutableStateOf(ConfigManager.getConfiguration(descriptor.group.value, config.key()))
-                            stringTextNode(descriptor, config, configStringsMap[key]!!)
-                        }
-                    }
-                }
-                else -> if (config.type?.isEnum == true) {
-                    enumNode(descriptor, config)
-                }
-            }
-        }
-
-    }
 }

--- a/client/src/main/java/meteor/ui/composables/items/Instructions.kt
+++ b/client/src/main/java/meteor/ui/composables/items/Instructions.kt
@@ -1,9 +1,0 @@
-package meteor.ui.composables.items
-
-import androidx.compose.runtime.Composable
-import meteor.plugins.Plugin
-
-@Composable
-fun instructions(lastPlugin: Plugin) {
-    lastPlugin.instructions()?.invoke()
-}

--- a/client/src/main/java/meteor/ui/composables/items/SectionItems.kt
+++ b/client/src/main/java/meteor/ui/composables/items/SectionItems.kt
@@ -10,58 +10,6 @@ import meteor.ui.composables.nodes.*
 import java.awt.Color
 
 fun LazyListScope.sectionItems(descriptor: ConfigDescriptor) {
-                items(items = descriptor.sections.sortedBy { it.section.name }.toMutableList()) { sect ->
-                    sectionItem(title = sect.name()) {
-                        val sections =
-                            descriptor.items.filter { it.item.section == sect.name() || sect.type == it.item.section }
-                        sections.forEach { config ->
-                            if (config.item.unhide.isBlank()) {
-                                when (config.type) {
-                                    Int::class.javaPrimitiveType, Int::class.java -> {
-                                        when {
-                                            config.range != null -> sliderIntNode(descriptor, config)
-                                            config.item.textArea -> intAreaTextNode(
-                                                descriptor,
-                                                config
-                                            )
-                                            else -> intTextNode(descriptor, config)
-                                        }
-                                    }
-                                    Boolean::class.java -> {
-                                        if (config.item.unhideKey == "")
-                                            booleanNode(descriptor, config)
-                                        else hiddenItems(config)
-                                    }
-                                    Color::class.java -> colorPickerNode(descriptor, config)
-                                    ModifierlessKeybind::class.java -> hotKeyNode(descriptor, config)
-                                    String::class.java -> {
-                                        when {
-                                            config.item.textArea -> stringAreaTextNode(descriptor, config)
-                                            else -> {
-                                                val key = "${descriptor.group.value}:${config.key()}"
-                                                configStringsMap[key]?.let {
-                                                    it.value = ConfigManager.getConfiguration(descriptor.group.value, config.key())!!
-                                                }
-                                                if (configStringsMap[key] == null)
-                                                    configStringsMap[key] = mutableStateOf(ConfigManager.getConfiguration(descriptor.group.value, config.key())!!)
-                                                stringTextNode(descriptor, config, configStringsMap[key]!!)
-                                            }
-                                        }
-                                    }
-                                    else -> if (config.type?.isEnum == true) {
 
-                                            if(config.item.unhideKey.isEmpty()) {
-                                                enumNode(descriptor, config)
-                                            }else
-                                                unhideEnum(config)
-                                    }
-                                }
-
-                            }
-
-                        }
-                    }
-
-                }
             }
 

--- a/client/src/main/java/meteor/ui/composables/items/TitleItems.kt
+++ b/client/src/main/java/meteor/ui/composables/items/TitleItems.kt
@@ -17,23 +17,5 @@ import meteor.config.descriptor.ConfigDescriptor
 import meteor.ui.composables.preferences.uiColor
 
 fun LazyListScope.titleItems(descriptor: ConfigDescriptor){
-        val title = descriptor.titles.sortedBy { it.title.position }.toMutableList()
-    items(items = title) {
-        BoxWithConstraints(
-            modifier = Modifier.fillMaxWidth(),
-            contentAlignment = Alignment.TopCenter
-        ) {
-            Text(
-                modifier = Modifier.fillMaxWidth().padding(it.title.padding.dp),
-                text = it.name(),
-                style = TextStyle(
-                    color = uiColor.value,
-                    fontSize = it.title.size.sp,
-                    textAlign = TextAlign.Center,
-                )
 
-            )
-        }
-
-    }
 }

--- a/client/src/main/java/meteor/ui/composables/items/UnhideItems.kt
+++ b/client/src/main/java/meteor/ui/composables/items/UnhideItems.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.unit.sp
 import meteor.config.ConfigManager
 import meteor.config.descriptor.ConfigItemDescriptor
 import meteor.config.legacy.ModifierlessKeybind
+import meteor.ui.composables.booleanValues
+import meteor.ui.composables.intValues
 import meteor.ui.composables.nodes.*
 import meteor.ui.composables.preferences.*
 
@@ -88,30 +90,47 @@ fun unhideEnum(config : ConfigItemDescriptor){
                 }
             }
             Spacer(Modifier.height(4.dp).background(background ) )
+
             when {
                 toggledEnum.value ->
                     descriptor.items.filter { it.item.unhide == hiddenEnum.key() }
                         .forEach { hiddenItem ->
+                            val key = "${descriptor.group.value}:${hiddenItem.key()}"
                             when (hiddenItem.type) {
                                 Int::class.javaPrimitiveType, Int::class.java -> {
+                                    intValues[key]?.let {
+                                        it.value = ConfigManager.getConfiguration(descriptor.group.value, config.key())?.toInt()
+                                    }
+                                    if (intValues[key] == null)
+                                        intValues[key] = mutableStateOf(ConfigManager.getConfiguration(descriptor.group.value, config.key())?.toInt())
                                     when {
-                                        hiddenItem.range != null -> sliderIntNode(
+                                        hiddenItem.range != null -> intTextNode(
                                             descriptor,
-                                            hiddenItem
+                                            hiddenItem,
+                                            intValues[key]!!
                                         )
                                         hiddenItem.item.textArea -> intAreaTextNode(
                                             descriptor,
-                                            hiddenItem
+                                            hiddenItem,
+                                            intValues[key]!!
                                         )
                                         else -> intTextNode(
-                                            descriptor, hiddenItem
+                                            descriptor, hiddenItem, intValues[key]!!
                                         )
                                     }
                                 }
-                                Boolean::class.javaPrimitiveType -> booleanNode(
-                                    descriptor,
-                                    hiddenItem
-                                )
+                                Boolean::class.javaPrimitiveType -> {
+                                    booleanValues[key]?.let {
+                                        it.value = ConfigManager.getConfiguration(descriptor.group.value, config.key())?.toBoolean()
+                                    }
+                                    if (booleanValues[key] == null)
+                                        booleanValues[key] = mutableStateOf(ConfigManager.getConfiguration(descriptor.group.value, config.key())?.toBoolean())
+                                    booleanNode(
+                                        descriptor,
+                                        hiddenItem,
+                                        booleanValues[key]!!
+                                    )
+                                }
                                 java.awt.Color::class.java -> colorPickerNode(
                                     descriptor,
                                     hiddenItem
@@ -191,26 +210,43 @@ fun hiddenItems(config : ConfigItemDescriptor){
             toggled.value ->
                 descriptor.items.filter { it.item.unhide == hidden.item.unhideKey }
                     .forEach { hiddenItem ->
+                        val key = "${descriptor.group.value}:${hiddenItem.key()}"
                         when (hiddenItem.type) {
                             Int::class.javaPrimitiveType, Int::class.java -> {
+                                intValues[key]?.let {
+                                    it.value = ConfigManager.getConfiguration(descriptor.group.value, hiddenItem.key())?.toInt()
+                                }
+                                if (intValues[key] == null)
+                                    intValues[key] = mutableStateOf(ConfigManager.getConfiguration(descriptor.group.value, hiddenItem.key())?.toInt())
+
                                 when {
-                                    hiddenItem.range != null -> sliderIntNode(
+                                    hiddenItem.range != null -> intTextNode(
                                         descriptor,
-                                        hiddenItem
+                                        hiddenItem,
+                                        intValues[key]!!
                                     )
                                     hiddenItem.item.textArea -> intAreaTextNode(
                                         descriptor,
-                                        hiddenItem
+                                        hiddenItem,
+                                        intValues[key]!!
                                     )
                                     else -> intTextNode(
-                                        descriptor, hiddenItem
+                                        descriptor, hiddenItem, intValues[key]!!
                                     )
                                 }
                             }
-                            Boolean::class.javaPrimitiveType -> booleanNode(
-                                descriptor,
-                                hiddenItem
-                            )
+                            Boolean::class.javaPrimitiveType -> {
+                                booleanValues[key]?.let {
+                                    it.value = ConfigManager.getConfiguration(descriptor.group.value, hiddenItem.key())?.toBoolean()
+                                }
+                                if (booleanValues[key] == null)
+                                    booleanValues[key] = mutableStateOf(ConfigManager.getConfiguration(descriptor.group.value, hiddenItem.key())?.toBoolean())
+                                booleanNode(
+                                    descriptor,
+                                    hiddenItem,
+                                    booleanValues[key]!!
+                                )
+                            }
                             java.awt.Color::class.java -> colorPickerNode(
                                 descriptor,
                                 hiddenItem

--- a/client/src/main/java/meteor/ui/composables/nodes/TypeNodes.kt
+++ b/client/src/main/java/meteor/ui/composables/nodes/TypeNodes.kt
@@ -33,10 +33,7 @@ import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 
 @Composable
-fun booleanNode(descriptor: ConfigDescriptor, configItemDescriptor: ConfigItemDescriptor) {
-    var toggled by remember {
-        mutableStateOf(ConfigManager.getConfiguration(descriptor.group.value, configItemDescriptor.key()).toBoolean())
-    }
+fun booleanNode(descriptor: ConfigDescriptor, configItemDescriptor: ConfigItemDescriptor, booleanValue: MutableState<Boolean?>) {
     Row(modifier = Modifier.fillMaxWidth().height(32.dp).background(background)) {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.Start, modifier = Modifier.fillMaxWidth(0.8f).height(32.dp).background(background)) {
             MaterialTheme(colors = darkThemeColors) {
@@ -45,9 +42,9 @@ fun booleanNode(descriptor: ConfigDescriptor, configItemDescriptor: ConfigItemDe
         }
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth().height(32.dp).background(background)) {
             MaterialTheme(colors = darkThemeColors) {
-                Checkbox(toggled, onCheckedChange = {
+                Checkbox(booleanValue.value!!, onCheckedChange = {
                     ConfigManager.setConfiguration(descriptor.group.value, configItemDescriptor.key(), it)
-                    toggled = it
+                    booleanValue.value = it
                 }, enabled = true, modifier = Modifier.scale(0.85f), colors = CheckboxDefaults.colors(checkedColor = uiColor.value, uncheckedColor = surface))
             }
         }

--- a/client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahConfig.java
+++ b/client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahConfig.java
@@ -11,6 +11,7 @@ import java.awt.Color;
 public interface ZulrahConfig extends Config {
 
 
+
    @ConfigSection(
        name = "General",
        description = "",
@@ -244,22 +245,42 @@ public interface ZulrahConfig extends Config {
    }
 
    @ConfigItem(
+           name = "",
+           keyName = "copyRangeGearPanel",
+           description = "",
+           position = 5,
+           composePanel = true,
+           section = fightHelperSection
+   )
+   default void copyRangeGearPanel() {}
+
+   @ConfigItem(
            keyName = "RangeIDs",
            name = "Range Gear",
            description = "",
            textField = true,
-           position = 5,
+           position = 6,
            section = fightHelperSection
    )
    default String RangeIDs() {
       return "";
    }
+
+   @ConfigItem(
+           name = "",
+           keyName = "copyMageGearPanel",
+           description = "",
+           position = 7,
+           composePanel = true,
+           section = fightHelperSection
+   )
+   default void copyMageGearPanel() {}
    @ConfigItem(
            keyName = "MageIDs",
            name = "Mage Gear",
            description = "",
            textField = true,
-           position = 6,
+           position = 8,
            section = fightHelperSection
    )
    default String MageIDs() {
@@ -270,7 +291,7 @@ public interface ZulrahConfig extends Config {
       name = "Prayer Helper",
       keyName = "prayerHelper",
       description = "Displays an overlay showing the correct prayer to use for the entirity of the Zulrah fight<br>Changes color dependent on whether or not you're praying correctly or not",
-      position = 7,
+      position = 9,
       section = fightHelperSection
    )
    default boolean prayerHelper() {
@@ -281,7 +302,7 @@ public interface ZulrahConfig extends Config {
       name = "Prayer Marker",
       keyName = "prayerMarker",
       description = "Marks the correct prayer to use in the prayer book to use for the entirity of the Zulrah fight<br>Changes color dependent on whether or not you're praying correctly or not",
-      position = 8,
+      position = 9,
       section = fightHelperSection
    )
    default boolean prayerMarker() {

--- a/client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahPlugin.kt
+++ b/client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahPlugin.kt
@@ -1,13 +1,11 @@
 package net.runelite.client.plugins.zulrah
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
@@ -26,10 +24,11 @@ import meteor.plugins.Plugin
 import meteor.plugins.PluginDescriptor
 import meteor.rs.ClientThread
 import meteor.rs.ClientThread.invokeLater
-import meteor.ui.composables.items.updateConfigUI
+import meteor.ui.composables.composePanelMap
 import meteor.ui.composables.preferences.secondColor
 import meteor.ui.composables.preferences.surface
 import meteor.ui.composables.preferences.uiColor
+import meteor.ui.composables.updateStringValue
 import meteor.ui.overlay.infobox.Counter
 import meteor.ui.overlay.infobox.InfoBoxManager
 import meteor.util.ImageUtil.loadImageResource
@@ -47,6 +46,7 @@ import java.util.*
 import java.util.function.BiConsumer
 import java.util.function.Consumer
 import java.util.stream.Collectors
+import kotlin.collections.HashMap
 
 @PluginDescriptor(
     name = "Zulrah Assist",
@@ -55,6 +55,11 @@ import java.util.stream.Collectors
     enabledByDefault = false
 )
 class ZulrahPlugin : Plugin(), KeyListener {
+    init {
+        setConfigComposable("znzulrah", "copyRangeGearPanel", copyRangeGearButton())
+        setConfigComposable("znzulrah", "copyMageGearPanel", copyMageGearButton())
+    }
+
     private val config = configuration<ZulrahConfig>(ZulrahConfig::class.java)
     private val keyManager = KeyManager
     private val infoBoxManager = InfoBoxManager
@@ -143,41 +148,16 @@ class ZulrahPlugin : Plugin(), KeyListener {
         handleTotalTicksInfoBox(true)
         //log.info("Zulrah Reset!");
     }
-    @Composable
-    override fun instructions() : @Composable () -> Unit? {
+
+    fun copyMageGearButton() : @Composable () -> Unit? {
         return {
             Spacer(Modifier.height(10.dp))
-            Text(
-                style = (TextStyle(fontSize = 12.sp)),
-                text = "EQUIP YOUR GEAR AND CLICK THE BUTTON",
-                color = secondColor.value,
-                textAlign = TextAlign.Center)
-            Column {
-                Spacer(Modifier.height(10.dp))
-                Button(
-                    modifier = Modifier.size(200.dp, 40.dp),
-                    onClick = {
-                        val i: ItemContainer? = client.getItemContainer(InventoryID.EQUIPMENT)
-                        val sb = StringBuilder()
-
-                        clientThread.invoke {
-                            i?.items?.forEach {
-                                if (it.id == -1 || it.id == 0) {
-                                    return@forEach
-                                }
-                                sb.append(it.name)
-                                sb.append(",")
-                            }
-                            ConfigManager.setConfiguration("znzulrah", "RangeIDs", sb.toString())
-                            updateConfigUI("znzulrah", "RangeIDs", sb.toString())
-                        }
-                    },
-                    colors = ButtonDefaults.textButtonColors(
-                        backgroundColor = surface
-                    )
-                ) {
-                    Text("Copy Range Gear", color = uiColor.value)
-                }
+            Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    style = (TextStyle(fontSize = 12.sp)),
+                    text = "EQUIP YOUR GEAR AND CLICK THE BUTTON",
+                    color = secondColor.value,
+                    textAlign = TextAlign.Center)
                 Spacer(Modifier.height(10.dp))
                 Button(
                     modifier = Modifier.size(200.dp, 40.dp),
@@ -194,7 +174,7 @@ class ZulrahPlugin : Plugin(), KeyListener {
                                 sb.append(",")
                             }
                             ConfigManager.setConfiguration("znzulrah", "MageIDs", sb.toString())
-                            updateConfigUI("znzulrah", "MageIDs", sb.toString())
+                            updateStringValue("znzulrah", "MageIDs", sb.toString())
                         }
                     },
                     colors = ButtonDefaults.textButtonColors(
@@ -202,6 +182,44 @@ class ZulrahPlugin : Plugin(), KeyListener {
                     )
                 ) {
                     Text("Copy Mage Gear", color = uiColor.value)
+                }
+            }
+        }
+    }
+
+    fun copyRangeGearButton() : @Composable () -> Unit? {
+        return {
+            Spacer(Modifier.height(10.dp))
+            Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    style = (TextStyle(fontSize = 12.sp)),
+                    text = "EQUIP YOUR GEAR AND CLICK THE BUTTON",
+                    color = secondColor.value,
+                    textAlign = TextAlign.Center)
+                Spacer(Modifier.height(10.dp))
+                Button(
+                    modifier = Modifier.size(200.dp, 40.dp),
+                    onClick = {
+                        val i: ItemContainer? = client.getItemContainer(InventoryID.EQUIPMENT)
+                        val sb = StringBuilder()
+
+                        clientThread.invoke {
+                            i?.items?.forEach {
+                                if (it.id == -1 || it.id == 0) {
+                                    return@forEach
+                                }
+                                sb.append(it.name)
+                                sb.append(",")
+                            }
+                            ConfigManager.setConfiguration("znzulrah", "RangeIDs", sb.toString())
+                            updateStringValue("znzulrah", "RangeIDs", sb.toString())
+                        }
+                    },
+                    colors = ButtonDefaults.textButtonColors(
+                        backgroundColor = surface
+                    )
+                ) {
+                    Text("Copy Range Gear", color = uiColor.value)
                 }
             }
         }


### PR DESCRIPTION
This allows you to have multiple custom compose panels anywhere you like defined by the kotlin plugin itself!

before there was only the instructions panel which was a bit basic to be honest. now we can do stuff like this:
![image](https://user-images.githubusercontent.com/2943260/215936106-83ad3b5f-8732-433a-8055-6e0340162891.png)

there being 3 custom panels in the above example, and this is again, a very basic example of what you can do with them.