### PR TITLE
client: allow plugins to default to off-thread events

### DIFF
--- a/api/src/main/java/net/runelite/api/Tile.kt
+++ b/api/src/main/java/net/runelite/api/Tile.kt
@@ -48,7 +48,7 @@ interface Tile : Locatable {
      *
      * @return the game objects
      */
-    val gameObjects: Array<GameObject>
+    val gameObjects: Array<GameObject?>
 
     /**
      * Gets the items held on this tile.
@@ -77,7 +77,7 @@ interface Tile : Locatable {
      *
      * @param wallObject the ground object
      */
-    var wallObject: WallObject
+    var wallObject: WallObject?
 
     /**
      * Gets the scene paint of the tile.

--- a/client/src/main/java/dev/hoot/api/commons/Time.java
+++ b/client/src/main/java/dev/hoot/api/commons/Time.java
@@ -13,12 +13,10 @@ public class Time
 	private static final meteor.Logger logger = new meteor.Logger("Time");
 	private static final int DEFAULT_POLLING_RATE = 10;
 
-	public static boolean sleep(long ms)
-	{
+	public static boolean sleep(long ms) throws Exception {
 		if (Game.getClient().isClientThread())
 		{
-			logger.debug("Tried to sleep on client thread!");
-			return false;
+			throw new Exception("Tried to sleep on client thread!");
 		}
 
 		try
@@ -34,13 +32,11 @@ public class Time
 		return false;
 	}
 
-	public static boolean sleep(int min, int max)
-	{
+	public static boolean sleep(int min, int max) throws Exception {
 		return sleep(Rand.nextInt(min, max));
 	}
 
-	public static boolean sleepUntil(BooleanSupplier supplier, int pollingRate, int timeOut)
-	{
+	public static boolean sleepUntil(BooleanSupplier supplier, int pollingRate, int timeOut) throws Exception {
 		if (Game.getClient().isClientThread())
 		{
 			logger.debug("Tried to sleepUntil on client thread!");
@@ -64,8 +60,7 @@ public class Time
 		return true;
 	}
 
-	public static boolean sleepUntil(BooleanSupplier supplier, int timeOut)
-	{
+	public static boolean sleepUntil(BooleanSupplier supplier, int timeOut) throws Exception {
 		return sleepUntil(supplier, DEFAULT_POLLING_RATE, timeOut);
 	}
 

--- a/client/src/main/java/dev/hoot/api/game/Worlds.java
+++ b/client/src/main/java/dev/hoot/api/game/Worlds.java
@@ -109,13 +109,11 @@ public class Worlds
 		return Game.getClient().getWorld();
 	}
 
-	public static void hopTo(World world)
-	{
+	public static void hopTo(World world) throws Exception {
 		hopTo(world, false);
 	}
 
-	public static void hopTo(World world, boolean spam)
-	{
+	public static void hopTo(World world, boolean spam) throws Exception {
 		if (!isHopperOpen())
 		{
 			openHopper();
@@ -161,8 +159,7 @@ public class Worlds
 				.isMembers();
 	}
 
-	public static void loadWorlds()
-	{
+	public static void loadWorlds() throws Exception {
 		if (Game.isOnLoginScreen())
 		{
 			openLobbyWorlds();

--- a/client/src/main/java/dev/hoot/api/input/Keyboard.java
+++ b/client/src/main/java/dev/hoot/api/input/Keyboard.java
@@ -47,8 +47,7 @@ public class Keyboard
 		canvas.dispatchEvent(event);
 	}
 
-	public static void type(char c)
-	{
+	public static void type(char c) throws Exception {
 		Canvas canvas = Game.getClient().getCanvas();
 		long time = System.currentTimeMillis();
 		int keyCode = KeyEvent.getExtendedKeyCodeForChar(c);
@@ -70,18 +69,15 @@ public class Keyboard
 		canvas.dispatchEvent(released);
 	}
 
-	public static void type(int number)
-	{
+	public static void type(int number) throws Exception {
 		type(String.valueOf(number));
 	}
 
-	public static void type(String text)
-	{
+	public static void type(String text) throws Exception {
 		type(text, false);
 	}
 
-	public static void type(String text, boolean sendEnter)
-	{
+	public static void type(String text, boolean sendEnter) throws Exception {
 		char[] chars = text.toCharArray();
 		for (char c : chars)
 		{
@@ -94,13 +90,11 @@ public class Keyboard
 		}
 	}
 
-	public static void sendEnter()
-	{
+	public static void sendEnter() throws Exception {
 		type((char) KeyEvent.VK_ENTER);
 	}
 
-	public static void sendSpace()
-	{
+	public static void sendSpace() throws Exception {
 		type((char) KeyEvent.VK_SPACE);
 	}
 }

--- a/client/src/main/java/dev/hoot/api/items/Bank.java
+++ b/client/src/main/java/dev/hoot/api/items/Bank.java
@@ -113,8 +113,7 @@ public class Bank extends Items
 		return -1;
 	}
 
-	public static void releasePlaceholders()
-	{
+	public static void releasePlaceholders() throws Exception {
 		if (!isSettingsOpen())
 		{
 			toggleSettings();

--- a/client/src/main/java/dev/hoot/api/items/GrandExchange.java
+++ b/client/src/main/java/dev/hoot/api/items/GrandExchange.java
@@ -324,33 +324,27 @@ public class GrandExchange
 		Game.getClient().interact(1, 57, 0, 30474264);
 	}
 
-	public static boolean sell(int itemId, int quantity, int price)
-	{
+	public static boolean sell(int itemId, int quantity, int price) throws Exception {
 		return exchange(false, itemId, quantity, price, true, false);
 	}
 
-	public static boolean sell(int itemId, int quantity, int price, boolean collect, boolean toBank)
-	{
+	public static boolean sell(int itemId, int quantity, int price, boolean collect, boolean toBank) throws Exception {
 		return exchange(false, itemId, quantity, price, collect, toBank);
 	}
 
-	public static boolean buy(int itemId, int quantity, int price)
-	{
+	public static boolean buy(int itemId, int quantity, int price) throws Exception {
 		return exchange(true, itemId, quantity, price, true, false);
 	}
 
-	public static boolean buy(int itemId, int quantity, int price, boolean collect, boolean toBank)
-	{
+	public static boolean buy(int itemId, int quantity, int price, boolean collect, boolean toBank) throws Exception {
 		return exchange(true, itemId, quantity, price, collect, toBank);
 	}
 
-	public static boolean exchange(boolean buy, int itemId, int quantity, int price)
-	{
+	public static boolean exchange(boolean buy, int itemId, int quantity, int price) throws Exception {
 		return exchange(buy, itemId, quantity, price, true, false);
 	}
 
-	public static boolean exchange(boolean buy, int itemId, int quantity, int price, boolean collect, boolean toBank)
-	{
+	public static boolean exchange(boolean buy, int itemId, int quantity, int price, boolean collect, boolean toBank) throws Exception {
 		if (!isOpen())
 		{
 			open();

--- a/client/src/main/java/dev/hoot/api/movement/Movement.java
+++ b/client/src/main/java/dev/hoot/api/movement/Movement.java
@@ -166,7 +166,12 @@ public class Movement
 		try
 		{
 			WorldPoint wp = WORLD_AREA_POINT_CACHE.get(worldArea.toWorldPointList());
-			return Walker.walkTo(wp, false);
+			try {
+				return Walker.walkTo(wp, false);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			return false;
 		}
 		catch (ExecutionException e)
 		{
@@ -177,7 +182,12 @@ public class Movement
 
 	public static boolean walkTo(WorldPoint worldPoint)
 	{
-		return Walker.walkTo(worldPoint, false);
+		try {
+			return Walker.walkTo(worldPoint, false);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return false;
 	}
 
 	public static boolean walkTo(Locatable locatable)
@@ -269,7 +279,12 @@ public class Movement
 	{
 		public static boolean walkTo(WorldPoint worldPoint)
 		{
-			return Walker.walkTo(worldPoint, true);
+			try {
+				return Walker.walkTo(worldPoint, true);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			return false;
 		}
 
 		public static boolean walkTo(Locatable locatable)

--- a/client/src/main/java/dev/hoot/api/movement/pathfinder/TeleportLoader.java
+++ b/client/src/main/java/dev/hoot/api/movement/pathfinder/TeleportLoader.java
@@ -231,7 +231,11 @@ public class TeleportLoader
 					Widget teleportItem = children[i];
 					if (teleportItem.getText().contains(target))
 					{
-						Keyboard.type((i + 1));
+						try {
+							Keyboard.type((i + 1));
+						} catch (Exception e) {
+							e.printStackTrace();
+						}
 						return;
 					}
 				}

--- a/client/src/main/java/dev/hoot/api/widgets/Dialog.java
+++ b/client/src/main/java/dev/hoot/api/widgets/Dialog.java
@@ -113,10 +113,14 @@ public class Dialog
 
 	public static void enterInput(String input)
 	{
-		Time.sleepUntil(Dialog::isEnterInputOpen, 2000);
-		if (isEnterInputOpen())
-		{
-			Keyboard.type(input, true);
+		try {
+			Time.sleepUntil(Dialog::isEnterInputOpen, 2000);
+			if (isEnterInputOpen())
+			{
+				Keyboard.type(input, true);
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
 		}
 	}
 
@@ -134,7 +138,11 @@ public class Dialog
 	{
 		if (Dialog.isOpen())
 		{
-			Keyboard.sendSpace();
+			try {
+				Keyboard.sendSpace();
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
 		}
 	}
 
@@ -142,7 +150,12 @@ public class Dialog
 	{
 		if (isViewingOptions())
 		{
-			Keyboard.type(index);
+			try {
+				Keyboard.type(index);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+
 			return true;
 		}
 

--- a/client/src/main/java/meteor/plugins/EventSubscriber.kt
+++ b/client/src/main/java/meteor/plugins/EventSubscriber.kt
@@ -4,6 +4,9 @@ import dev.hoot.api.events.AutomatedMenu
 import dev.hoot.api.events.MenuActionProcessed
 import eventbus.Events
 import eventbus.events.*
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import meteor.Main
 import meteor.events.InfoBoxMenuClicked
 import meteor.events.NpcLootReceived
@@ -12,7 +15,7 @@ import meteor.events.PluginChanged
 import net.runelite.api.events.MenuOpened
 import org.rationalityfrontline.kevent.*
 
-open class EventSubscriber : KEventSubscriber {
+open class EventSubscriber(open var daemon: Boolean = false) : KEventSubscriber {
     var eventListening: Boolean = false
     open fun onNpcLootReceived(it: NpcLootReceived){}
     open fun onPlayerLootReceived(it: PlayerLootReceived){}
@@ -105,8 +108,16 @@ open class EventSubscriber : KEventSubscriber {
     open fun onPacketQueued(it: PacketQueued) {}
 
     open fun onCheckClick(it: CheckClick) {}
+
+    @OptIn(DelicateCoroutinesApi::class)
     open fun executeIfListening(unit: () -> (Unit)) {
         if (eventListening)
+            if (daemon) {
+                GlobalScope.launch {
+                    unit()
+                }
+                return
+            }
             unit()
     }
 

--- a/client/src/main/java/meteor/plugins/Plugin.kt
+++ b/client/src/main/java/meteor/plugins/Plugin.kt
@@ -1,7 +1,5 @@
 package meteor.plugins
 
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
 import meteor.Main
 import meteor.config.ConfigManager
@@ -15,7 +13,7 @@ import meteor.ui.composables.preferences.pluginPanelIsOpen
 import meteor.ui.composables.toolbar.ToolbarButton
 import meteor.ui.overlay.Overlay
 
-open class Plugin() : EventSubscriber() {
+open class Plugin(override var daemon: Boolean = false) : EventSubscriber(daemon = daemon) {
     var configuration: Config? = null
 
     open var client = Main.client

--- a/client/src/main/java/meteor/plugins/blastmine/BlastMineRockOverlay.kt
+++ b/client/src/main/java/meteor/plugins/blastmine/BlastMineRockOverlay.kt
@@ -115,7 +115,7 @@ class BlastMineRockOverlay internal constructor(plugin: BlastMinePlugin, config:
         val z = client.plane
         var x = rock.gameObject.localLocation.x / Perspective.LOCAL_TILE_SIZE
         var y = rock.gameObject.localLocation.y / Perspective.LOCAL_TILE_SIZE
-        val orientation = tiles[z][x][y].wallObject.orientationA
+        val orientation = tiles[z][x][y].wallObject?.orientationA
         when (orientation) {
             1 -> x--
             4 -> x++

--- a/client/src/main/java/meteor/plugins/meteor/Meteor.kt
+++ b/client/src/main/java/meteor/plugins/meteor/Meteor.kt
@@ -23,6 +23,7 @@ import meteor.config.ConfigManager
 
 import meteor.plugins.Plugin
 import meteor.plugins.PluginDescriptor
+import meteor.rs.ClientThread
 import meteor.ui.themes.MeteorliteTheme
 import net.runelite.api.Constants
 import net.runelite.api.MenuAction
@@ -32,7 +33,7 @@ import java.awt.Point
 import java.awt.Rectangle
 
 @PluginDescriptor(name = "Meteor", enabledByDefault = true, disabledOnStartup = false)
-class Meteor : Plugin() {
+class Meteor : Plugin(daemon = true) {
     var config = configuration<MeteorConfig>()
     val log = Logger("Meteor")
     val autoInteractOverlay = overlay(AutoInteractOverlay(config))
@@ -51,8 +52,10 @@ class Meteor : Plugin() {
         val mouseHandler = client.mouseHandler
         try {
             if (config.mouseBehavior() != MouseBehavior.DISABLED) {
-                mouseHandler.sendMovement(clickPoint.x, clickPoint.y)
-                ClientPackets.queueClickPacket(clickPoint.x, clickPoint.y)
+                ClientThread.invoke {
+                    ClientPackets.queueClickPacket(clickPoint.x, clickPoint.y)
+                    mouseHandler.sendMovement(clickPoint.x, clickPoint.y)
+                }
             }
             GameThread.invoke {
                 try {

--- a/client/src/main/java/meteor/plugins/objectindicators/ObjectIndicatorsPlugin.kt
+++ b/client/src/main/java/meteor/plugins/objectindicators/ObjectIndicatorsPlugin.kt
@@ -194,7 +194,7 @@ class ObjectIndicatorsPlugin : Plugin() {
         if (tile == null) {
             return null
         }
-        val tileGameObjects: Array<GameObject>? = tile.gameObjects
+        val tileGameObjects: Array<GameObject?>? = tile.gameObjects
         val tileDecorativeObject: DecorativeObject? = tile.decorativeObject
         val tileWallObject: WallObject? = tile.wallObject
         val groundObject: GroundObject? = tile.groundObject

--- a/client/src/main/java/meteor/util/GameEventManager.kt
+++ b/client/src/main/java/meteor/util/GameEventManager.kt
@@ -96,9 +96,9 @@ object GameEventManager {
                 }
                 Arrays.stream(tile.gameObjects)
                     .filter { obj: GameObject? -> Objects.nonNull(obj) }
-                    .filter { obj: GameObject -> obj.sceneMinLocation == tile.sceneLocation }
-                    .forEach { obj: GameObject ->
-                        val objectSpawned = GameObjectSpawned(tile, obj)
+                    .filter { obj: GameObject? -> obj?.sceneMinLocation == tile.sceneLocation }
+                    .forEach { obj: GameObject? ->
+                        val objectSpawned = GameObjectSpawned(tile, obj!!)
                         Main.eventBus.post(Events.GAME_OBJECT_SPAWNED, objectSpawned)
                     }
                 Optional.ofNullable(tile.itemLayer).ifPresent { itemLayer: ItemLayer ->


### PR DESCRIPTION
This allows plugins to flag as a daemon like so:

```kotlin
class WorldMapWalkerPlugin : Plugin(daemon = true) {
```

to make events run as a new global thread instead of running on the client thread.

This also fixes some known usages of sleeping on client thread issues, and should make things like the walker much more reliable and lag free!, but I'm sure there are more of them. If you see an exception related to sleeping, let me know!