### PR TITLE
client: auth init

### DIFF
--- a/client/src/main/java/dev/hoot/api/RegionConfig.java
+++ b/client/src/main/java/dev/hoot/api/RegionConfig.java
@@ -1,19 +1,15 @@
 package dev.hoot.api;
 
-import meteor.config.legacy.Config;
-import meteor.config.legacy.ConfigGroup;
-import meteor.config.legacy.ConfigItem;
-import meteor.config.legacy.Range;
-import meteor.config.legacy.Button;
+import meteor.config.legacy.*;
 
 @ConfigGroup("regions")
 public interface RegionConfig extends Config
 {
+	@Secret
 	@ConfigItem(
 			keyName = "apiKey",
 			name = "API Key",
 			description = "API Key used for contributing collision data to our backend.",
-			secret = true,
 			position = 0
 	)
 	default String apiKey()

--- a/client/src/main/java/meteor/config/legacy/ConfigItem.kt
+++ b/client/src/main/java/meteor/config/legacy/ConfigItem.kt
@@ -24,6 +24,5 @@ package meteor.config.legacy
     val disabledByValue: String = "",
     val textArea: Boolean = false,
     val textField: Boolean = false,
-    val secret: Boolean = false,
     val composePanel: Boolean = false,
     )

--- a/client/src/main/java/meteor/plugins/autologhop/AutoLogHopConfig.kt
+++ b/client/src/main/java/meteor/plugins/autologhop/AutoLogHopConfig.kt
@@ -1,9 +1,6 @@
 package meteor.plugins.autologhop
 
-import meteor.config.legacy.Config
-import meteor.config.legacy.ConfigGroup
-import meteor.config.legacy.ConfigItem
-import meteor.config.legacy.ConfigSection
+import meteor.config.legacy.*
 
 @ConfigGroup("autologhop")
 interface AutoLogHopConfig : Config {
@@ -43,14 +40,14 @@ interface AutoLogHopConfig : Config {
         return ""
     }
 
+    @Secret
     @ConfigItem(
         keyName = "password",
         name = "password",
         description = "Password for login",
         position = 13,
         section = "AutoLogHop",
-        textField = true,
-        secret = true
+        textField = true
     )
     fun password(): String {
         return ""

--- a/client/src/main/java/meteor/plugins/meteor/MeteorConfig.kt
+++ b/client/src/main/java/meteor/plugins/meteor/MeteorConfig.kt
@@ -12,11 +12,22 @@ import java.awt.Color
 
 @ConfigGroup(Configuration.MASTER_GROUP)
 interface MeteorConfig : Config {
+    @Secret
+    @ConfigItem(
+        keyName = "authKey",
+        name = "Auth Key",
+        description = "",
+        position = 0
+    )
+    fun authKey(): String {
+        return ""
+    }
+
     @ConfigItem(
         name = "Always on top",
         keyName = "alwaysOnTop",
         description = "",
-        position = 0,
+        position = 1,
     )
     fun alwaysOnTop(): Boolean {
         return false
@@ -73,7 +84,7 @@ interface MeteorConfig : Config {
         name = "Enable console",
         keyName = "console",
         description = "",
-        position = 0,
+        position = 1,
     )
     fun console(): Boolean {
         return false

--- a/client/src/main/java/meteor/rmi/RMIClient.kt
+++ b/client/src/main/java/meteor/rmi/RMIClient.kt
@@ -1,0 +1,11 @@
+package meteor.rmi
+
+import meteor.Main.rmiHost
+import java.rmi.Remote
+import java.rmi.registry.LocateRegistry
+
+open class RMIClient<T: Remote>(var host: String = rmiHost, var name: String = "", var port: Int) {
+    fun connect(): T {
+        return LocateRegistry.getRegistry(host, port).lookup(name) as T
+    }
+}

--- a/client/src/main/java/meteor/rmi/handshake/HandshakeClient.kt
+++ b/client/src/main/java/meteor/rmi/handshake/HandshakeClient.kt
@@ -1,0 +1,6 @@
+package meteor.rmi.handshake
+
+import meteor.rmi.RMIClient
+import java.rmi.Remote
+
+class HandshakeClient<T : Remote> : RMIClient<T>(name = "handshake", port = 4000)

--- a/client/src/main/java/meteor/rmi/handshake/HandshakeService.kt
+++ b/client/src/main/java/meteor/rmi/handshake/HandshakeService.kt
@@ -1,0 +1,9 @@
+package meteor.rmi.handshake
+
+import java.rmi.Remote
+import java.rmi.RemoteException
+
+interface HandshakeService : Remote {
+    @Throws(RemoteException::class)
+    fun handshake(uuid: String): String
+}


### PR DESCRIPTION
This is an example of basic but effective auth when combined with obfuscation

meteor.rmi.handshake is a remote method invocation example.

1. a user goes to our discord, DMs the meteor bot with the /auth command (even now you will only ever get one, keep it safe)
2. user enters the auth key in Meteor config
3. restart the client, look for "RMI round-trip -" debug print at login screen

The most effective way to use this system is to obfuscate your private plugins current state using a snapshot of game info. Thus requiring any would-be crackers to HAVE to actually implement code to get the plugin working off network.