### PR TITLE
project: fix injector bytecode, disable -noverify jvm argument

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -135,7 +135,6 @@ compose {
                 //"-Dsun.java2d.uiScale=1.0",
 
                 "-ea",
-                "-noverify",
                 "-XX:+UseDynamicNumberOfGCThreads",
                 "-XX:+UseZGC",
                 "-Xmx2048m",

--- a/client/src/main/java/meteor/launcher/CreateLauncherUpdate.kt
+++ b/client/src/main/java/meteor/launcher/CreateLauncherUpdate.kt
@@ -9,7 +9,7 @@ import java.util.zip.CRC32
 import kotlin.math.ceil
 
 object CreateLauncherUpdate {
-    private val releaseVersion = "264"
+    private val releaseVersion = "269"
     private val runtimeVersion = "17.0.5"
 
     private val release = LauncherUpdate()

--- a/deobfuscator/src/main/java/net/runelite/asm/pool/Class.java
+++ b/deobfuscator/src/main/java/net/runelite/asm/pool/Class.java
@@ -26,7 +26,11 @@ package net.runelite.asm.pool;
 
 public class Class
 {
-	private final String name;
+	private String name;
+
+	public void fixEnum() {
+		name = "[L" + name + ";";
+	}
 
 	public Class(String name)
 	{

--- a/injector/src/main/java/com/openosrs/injector/Injector.java
+++ b/injector/src/main/java/com/openosrs/injector/Injector.java
@@ -13,6 +13,7 @@ import com.openosrs.injector.injection.InjectTaskHandler;
 import com.openosrs.injector.injectors.*;
 import com.openosrs.injector.injectors.raw.*;
 import com.openosrs.injector.rsapi.RSApi;
+import com.openosrs.injector.transformers.EnumInvokeVirtualFixer;
 import com.openosrs.injector.transformers.InjectTransformer;
 import com.openosrs.injector.transformers.Java8Ifier;
 import com.openosrs.injector.transformers.SourceChanger;
@@ -109,6 +110,8 @@ public class Injector extends InjectData implements InjectTaskHandler
 		injector.vanilla.removeClass(reflection);
 
 		transform(new Java8Ifier(this));
+
+		transform(new EnumInvokeVirtualFixer(this));
 
 		inject(new CreateAnnotations(this));
 

--- a/injector/src/main/java/com/openosrs/injector/transformers/EnumInvokeVirtualFixer.java
+++ b/injector/src/main/java/com/openosrs/injector/transformers/EnumInvokeVirtualFixer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, ThatGamerBlue <thatgamerblue@gmail.com>
+ * All rights reserved.
+ *
+ * This code is licensed under GPL3, see the complete license in
+ * the LICENSE file in the root directory of this submodule.
+ */
+package com.openosrs.injector.transformers;
+
+import com.openosrs.injector.injection.InjectData;
+
+import net.runelite.asm.ClassFile;
+import net.runelite.asm.Method;
+import net.runelite.asm.attributes.code.Instruction;
+import net.runelite.asm.attributes.code.instructions.InvokeVirtual;
+
+public class EnumInvokeVirtualFixer extends InjectTransformer
+{
+	private int fixedEnums = 0;
+	public EnumInvokeVirtualFixer(InjectData inject)
+	{
+		super(inject);
+	}
+
+	@Override
+	void transformImpl()
+	{
+		inject.forEachPair(this::fixEnumInvokeVirtuals);
+	}
+
+	private void fixEnumInvokeVirtuals(ClassFile rsc, ClassFile vanilla)
+	{
+		if (vanilla.isEnum()) {
+			Method valuesMethod = vanilla.findMethod("values");
+			if (valuesMethod != null) {
+				for (Instruction insn : valuesMethod.getCode().getInstructions()) {
+					if (insn instanceof InvokeVirtual invokeVirtual) {
+						invokeVirtual.getMethod().getClazz().fixEnum();
+						fixedEnums++;
+					}
+				}
+			}
+		}
+	}
+}

--- a/injector/src/main/java/com/openosrs/injector/transformers/InjectTransformer.java
+++ b/injector/src/main/java/com/openosrs/injector/transformers/InjectTransformer.java
@@ -17,7 +17,7 @@ import net.runelite.asm.Named;
 public abstract class InjectTransformer implements Named
 {
 	protected final InjectData inject;
-	protected final Logger log = new Logger(this.getClass().getName());
+	protected final Logger log = new Logger("Injector");
 	private Stopwatch stopwatch;
 
 	public final void transform()


### PR DESCRIPTION
This fixes a long standing bug in runelites injector that mashes enum classes.
It required us to use -noverify on desktop and also to enable a developer option on android to use the client at all.

I'm happy to say that is no longer the case!