### PR TITLE
project: publish client-all, remove other publications

### DIFF
--- a/.idea/runConfigurations/Publish_Fat_Jar.xml
+++ b/.idea/runConfigurations/Publish_Fat_Jar.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Publish Fat Jar" type="GradleRunConfiguration" factoryName="Gradle">
+    <selectedOptions>
+      <option name="external.system.vm.parameters.fragment" />
+    </selectedOptions>
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="shadowJar" />
+          <option value="client:publishToMavenLocal" />
+        </list>
+      </option>
+      <option name="vmOptions" value="-Xmx2048m" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     java
     kotlin("jvm")
-    `maven-publish`
 }
 
 group = "meteor"
@@ -9,20 +8,7 @@ version = "1.0.4"
 repositories {
     mavenCentral()
 }
-publishing {
-    repositories {
-        mavenLocal()
-    }
 
-    publications {
-        create<MavenPublication>("maven") {
-            groupId = rootProject.group.toString()
-            artifactId = project.name
-            version = rootProject.project.version.toString()
-            from(components["java"])
-        }
-    }
-}
 dependencies {
     implementation(project(":annotations"))
     implementation(project(":logger"))

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -17,6 +17,7 @@ val majorRelease by rootProject.extra { "1.7" }
 val release by rootProject.extra { "2" }
 group = "meteor"
 version = "${majorRelease.split(".")[0]}.${majorRelease.split(".")[1]}.$release"
+
 publishing {
     repositories {
         mavenLocal()
@@ -25,12 +26,17 @@ publishing {
     publications {
         create<MavenPublication>("maven") {
             groupId = rootProject.group.toString()
-            artifactId = project.name
-            version = rootProject.project.version.toString()
-            from(components["java"])
+            artifactId = project.name + "-all"
+            version = "0.0.0"
+            afterEvaluate {
+                val shadowJar = tasks.findByName("shadowJar")
+                if (shadowJar == null) from(components["java"])
+                else artifact(shadowJar)
+            }
         }
     }
 }
+
 repositories {
     mavenLocal()
     maven {url = uri("https://androidx.dev/storage/compose-compiler/repository")}
@@ -149,9 +155,11 @@ compose {
     }
 }
 
+
 tasks {
-    named<ShadowJar>("shadowJar") {
-        archiveBaseName.set("shadow")
+    shadowJar {
+        baseName = "meteor-client-all"
+        classifier = ""
         mergeServiceFiles()
         manifest {
             attributes(mapOf("Main-Class" to "meteor.Main"))

--- a/client/src/main/java/meteor/Main.kt
+++ b/client/src/main/java/meteor/Main.kt
@@ -325,8 +325,8 @@ object Main : ApplicationScope, EventSubscriber() {
             if (it.data.group == Configuration.MASTER_GROUP)
                 if (it.data.key == "fullscreen") {
                     shouldExit = false
-                    val gpuIsRunning = PluginManager.get<GpuPlugin>().running
-                    val gpuHdIsRunning = PluginManager.get<HdPlugin>().running
+                    val gpuIsRunning = PluginManager.getOrNull<GpuPlugin>()?.running == true
+                    val gpuHdIsRunning = PluginManager.getOrNull<HdPlugin>()?.running == true
                     var enabledGPUPlugin = false
                     if (gpuIsRunning) {
                         PluginManager.stop(PluginManager.get<GpuPlugin>())

--- a/client/src/main/java/meteor/launcher/CreateLauncherUpdate.kt
+++ b/client/src/main/java/meteor/launcher/CreateLauncherUpdate.kt
@@ -9,7 +9,7 @@ import java.util.zip.CRC32
 import kotlin.math.ceil
 
 object CreateLauncherUpdate {
-    private val releaseVersion = "284-UNSTABLE"
+    private val releaseVersion = "286"
     private val runtimeVersion = "17.0.5"
 
     private val release = LauncherUpdate()

--- a/client/src/main/java/meteor/plugins/PluginManager.kt
+++ b/client/src/main/java/meteor/plugins/PluginManager.kt
@@ -413,6 +413,10 @@ object PluginManager {
         return plugins.filterIsInstance<T>().first()
     }
 
+    inline fun <reified T : Plugin> getOrNull(): T? {
+        return plugins.filterIsInstance<T>().firstOrNull()
+    }
+
     inline fun <reified T : Plugin> restart() {
         val it = plugins.filterIsInstance<T>().first()
         stop(it)

--- a/eventbus/build.gradle.kts
+++ b/eventbus/build.gradle.kts
@@ -1,8 +1,6 @@
 plugins {
     kotlin("jvm")
     java
-    `maven-publish`
-
 }
 
 group = "org.meteorlite"
@@ -11,20 +9,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     mavenCentral()
 }
-publishing {
-    repositories {
-        mavenLocal()
-    }
 
-    publications {
-        create<MavenPublication>("maven") {
-            groupId = rootProject.group.toString()
-            artifactId = project.name
-            version = rootProject.project.version.toString()
-            from(components["java"])
-        }
-    }
-}
 dependencies {
     val coroutinesVersion = "1.6.4"
     /** Kotlin --------------------------------------------------------- */


### PR DESCRIPTION
This adds a Publish Fat Jar run configuration that will allow you to call:

```java
runtimeOnly(group = "meteor", name = "client-all", version = "0.0.0")
```
    
    
in your externals and have access to everything the client does.    