### PR TITLE
External Plugins throw ClassDefNotFound error - Fix

### DIFF
--- a/client/src/main/java/meteor/plugins/Plugin.kt
+++ b/client/src/main/java/meteor/plugins/Plugin.kt
@@ -25,7 +25,7 @@ open class Plugin(override var daemon: Boolean = false) : EventSubscriber(daemon
         return javaClass.getAnnotation(PluginDescriptor::class.java)
     }
 
-    open fun getName(): String? {
+    open fun getName(): String {
         return getDescriptor().name
     }
 

--- a/client/src/main/java/meteor/plugins/PluginManager.kt
+++ b/client/src/main/java/meteor/plugins/PluginManager.kt
@@ -402,7 +402,7 @@ object PluginManager {
                     ConfigManager.setConfiguration(plugin.javaClass.simpleName, "pluginEnabled", false)
 
                 plugins.add(plugin)
-                classLoaders[plugin.getName().orEmpty()] = cl;
+                classLoaders[plugin.getName()] = cl;
                 runningMap[plugin] = plugin.shouldEnable()
                 if (runningMap[plugin]!!)
                     start(plugin)


### PR DESCRIPTION
Classloader used the "use" keyword which disposes the Classloader once the plugin class was instantiated. 
This means that any other classes used at runtime are unavailable and caused the class def not found issue. 

Fixed by keeping the classloaders open, and when the plugin is reloaded, the classloader is disposed of. 